### PR TITLE
add --regen-ocean option to regenerate bug-affected tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,23 @@ To run the unit tests, type ``pytest``
 
 A systemd service is provided for running the WSGI server.
 
+## Tools
+
+- **fast_gen.py** - Fast terrain DAT file generator using numpy. Generates `.DAT.gz` files from SRTM HGT data with multiprocessing. Supports both land and ocean tiles, and both SRTM1 (30m) and SRTM3 (100m) spacing. Use `--lat-range` to generate ocean tiles for a latitude range.
+
+- **create_filelist.py** - Creates the `filelist_python` pickle file for an HGT directory. This file is used by `srtm.py` to look up available tiles without scanning the directory each time.
+
+- **create_continents.py** - Packages terrain DAT files into per-continent ZIP archives for distribution, using the filelist_python continent mapping from `srtm.py`.
+
+- **resample_hgt.py** - Downsamples SRTM1 HGT files (3601x3601) to SRTM3 (1201x1201) by taking every 3rd pixel. Takes input and output directory names.
+
+- **srtm1_to_srtm3.py** - Resamples SRTM1 HGT data to SRTM3 resolution using mean pooling via scipy interpolation.
+
+- **find_steep.py** - Scans HGT or DAT files for neighbouring points exceeding a height difference threshold. Reports count, max difference, and lat/lon of the steepest point. Useful for finding data anomalies.
+
+- **slice_graph.py** - Altitude profile visualiser. Plots a horizontal slice through terrain tiles comparing DAT and HGT data side by side, replicating both AP_Terrain and srtm.py interpolation methods.
+
+- **terrain_view.py** - 2D terrain visualiser. Displays DAT or HGT files as colour-mapped images with mouse-over lat/lon and height readout. Supports `--diff` mode to compare two files.
+
+- **offline_check.py** - Validates terrain DAT files for corruption by checking CRC, block structure, and coverage.
+

--- a/create_continents.py
+++ b/create_continents.py
@@ -13,8 +13,9 @@ from argparse import ArgumentParser
 def compressFiles(fileList, continent, outfolder):
     # create a zip file comprised of dat.gz tiles
     zipthis = os.path.join(outfolder, continent + ".zip")
-        
-    with zipfile.ZipFile(zipthis, 'w') as terrain_zip:
+    tmp_zipthis = zipthis + ".tmp"
+
+    with zipfile.ZipFile(tmp_zipthis, 'w') as terrain_zip:
         for fn in fileList:
             if not os.path.exists(fn):
                 #download if required
@@ -34,6 +35,8 @@ def compressFiles(fileList, continent, outfolder):
                 terrain_zip.writestr(os.path.basename(fn)[:-3], myio.read(),
                                      compress_type=zipfile.ZIP_DEFLATED)
 
+    # Atomic rename to final location
+    os.rename(tmp_zipthis, zipthis)
     return True
 
 if __name__ == '__main__':
@@ -68,8 +71,6 @@ if __name__ == '__main__':
 
     # Add the files
     for continent in continents:
-        if os.path.exists(os.path.join(args.outfolder, continent + ".zip")):
-            os.remove(os.path.join(args.outfolder, continent + ".zip"))
         print("Processing: " + continent)
         files = continents[continent]
         compressFiles(files, continent, args.outfolder)

--- a/create_continents.py
+++ b/create_continents.py
@@ -46,10 +46,12 @@ if __name__ == '__main__':
 
     parser.add_argument("infolder", type=str, default="./files")
     parser.add_argument("outfolder", type=str, default="./continents")
+    parser.add_argument("--cachedir", type=str, default=None,
+                        help="Directory containing filelist_python for continent mapping")
 
     args = parser.parse_args()
 
-    downloader = srtm.SRTMDownloader(debug=False)
+    downloader = srtm.SRTMDownloader(debug=False, cachedir=args.cachedir)
     downloader.loadFileList()
 
     continents = {}

--- a/create_filelist.py
+++ b/create_filelist.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Create filelist_python for a directory of .hgt.zip files.
+
+The filelist_python is a pickle file used by srtm.py to look up
+which HGT files are available and where they are located.
+"""
+
+import os
+import sys
+import re
+import pickle
+import argparse
+
+
+def create_filelist(directory):
+    """Scan directory for .hgt.zip files and create filelist_python."""
+    filename_regex = re.compile(r"([NS])(\d{2})([EW])(\d{3})\.hgt\.zip")
+    filelist = {}
+
+    for name in os.listdir(directory):
+        match = filename_regex.match(name)
+        if match is None:
+            continue
+        lat = int(match.group(2))
+        lon = int(match.group(4))
+        if match.group(1) == "S":
+            lat = -lat
+        if match.group(3) == "W":
+            lon = -lon
+        filelist[(lat, lon)] = ("/", name)
+
+    outpath = os.path.join(directory, "filelist_python")
+    tmppath = outpath + ".tmp"
+    with open(tmppath, 'wb') as f:
+        pickle.dump(filelist, f)
+    os.replace(tmppath, outpath)
+
+    print("Created %s with %u entries" % (outpath, len(filelist)))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create filelist_python for an HGT directory")
+    parser.add_argument("directory", help="Directory containing .hgt.zip files")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.directory):
+        print("Error: %s is not a directory" % args.directory, file=sys.stderr)
+        sys.exit(1)
+
+    create_filelist(args.directory)

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -349,7 +349,7 @@ def dat_filename(lat_int, lon_int):
                                      ew, min(abs(lon_int), 999))
 
 
-def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, tile_total=None):
+def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, tile_total=None, overwrite=False):
     """Process a single HGT tile to produce a DAT.gz file."""
     coords = parse_hgt_filename(hgt_file)
     if coords is None:
@@ -361,7 +361,7 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, til
     outpath = os.path.join(output_dir, outname)
     progress = f"[{tile_idx}/{tile_total}] " if tile_idx is not None else ""
 
-    if os.path.exists(outpath):
+    if os.path.exists(outpath) and not overwrite:
         print(f"{progress}Skipping {outname} (exists)")
         return
 
@@ -428,6 +428,8 @@ def main():
                         help='Grid spacing in metres (default: 30)')
     parser.add_argument('--processes', type=int, default=8,
                         help='Number of parallel workers (default: 8)')
+    parser.add_argument('--overwrite', action='store_true',
+                        help='Overwrite existing output files')
     args = parser.parse_args()
 
     # Scan for HGT files (flat or continent subdirs)
@@ -452,7 +454,7 @@ def main():
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    work_args = [(f, hgt_map, args.output_dir, args.spacing, "4.1", i + 1, total)
+    work_args = [(f, hgt_map, args.output_dir, args.spacing, "4.1", i + 1, total, args.overwrite)
                  for i, (coords, f) in enumerate(hgt_files)]
 
     if args.processes <= 1:

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -350,6 +350,16 @@ def dat_filename(lat_int, lon_int):
                                      ew, min(abs(lon_int), 999))
 
 
+def write_dat_gz(outpath, outname, file_buf):
+    """Compress and write a DAT file atomically."""
+    dat_name = outname[:-3]  # .DAT name for gzip header
+    tmp_path = outpath + '.tmp'
+    with open(tmp_path, 'wb') as raw_f:
+        with gzip.GzipFile(dat_name, 'wb', fileobj=raw_f) as f:
+            f.write(file_buf)
+    os.rename(tmp_path, outpath)
+
+
 def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, tile_total=None, overwrite=False):
     """Process a single HGT tile to produce a DAT.gz file."""
     coords = parse_hgt_filename(hgt_file)
@@ -402,14 +412,38 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, til
 
     # Step 6: Compress and write atomically
     os.makedirs(output_dir, exist_ok=True)
-    dat_name = outname[:-3]  # .DAT name for gzip header
-    tmp_path = outpath + '.tmp'
-    with open(tmp_path, 'wb') as raw_f:
-        with gzip.GzipFile(dat_name, 'wb', fileobj=raw_f) as f:
-            f.write(file_buf)
-    os.rename(tmp_path, outpath)
+    write_dat_gz(outpath, outname, file_buf)
 
     print(f"{progress}Generated {outname} ({n_blocks} blocks)")
+
+
+def process_ocean_tile(args):
+    """Generate an all-zero DAT.gz file for an ocean tile."""
+    try:
+        lat_int, lon_int, output_dir, spacing, fmt, tile_idx, tile_total, overwrite = args
+        outname = dat_filename(lat_int, lon_int)
+        outpath = os.path.join(output_dir, outname)
+        progress = f"[{tile_idx}/{tile_total}] " if tile_idx is not None else ""
+
+        if os.path.exists(outpath) and not overwrite:
+            return
+
+        valid_blocks, stride = enumerate_valid_blocks(lat_int, lon_int, spacing, fmt)
+        if not valid_blocks:
+            return
+
+        n_blocks = len(valid_blocks)
+        all_heights = np.zeros((n_blocks, TERRAIN_GRID_BLOCK_SIZE_X,
+                                TERRAIN_GRID_BLOCK_SIZE_Y), dtype=np.int16)
+
+        file_buf = pack_dat_file(valid_blocks, all_heights, lat_int, lon_int, spacing, fmt)
+        write_dat_gz(outpath, outname, file_buf)
+
+        print(f"{progress}Ocean {outname} ({n_blocks} blocks)")
+    except Exception as e:
+        print(f"Error generating ocean tile ({lat_int},{lon_int}): {e}")
+        import traceback
+        traceback.print_exc()
 
 
 def process_tile_wrapper(args):
@@ -433,6 +467,9 @@ def main():
                         help='Number of parallel workers (default: 8)')
     parser.add_argument('--overwrite', action='store_true',
                         help='Overwrite existing output files')
+    parser.add_argument('--lat-range', type=int, nargs=2, metavar=('MIN', 'MAX'),
+                        help='Generate ocean tiles for all longitudes in this latitude range '
+                             '(e.g. --lat-range -85 84 for full world coverage)')
     args = parser.parse_args()
 
     # Scan for HGT files (flat or continent subdirs)
@@ -457,6 +494,7 @@ def main():
 
     os.makedirs(args.output_dir, exist_ok=True)
 
+    # Process land tiles from HGT data
     work_args = [(f, hgt_map, args.output_dir, args.spacing, "4.1", i + 1, total, args.overwrite)
                  for i, (coords, f) in enumerate(hgt_files)]
 
@@ -466,6 +504,32 @@ def main():
     else:
         with Pool(processes=args.processes) as pool:
             pool.map(process_tile_wrapper, work_args, chunksize=1)
+
+    # Generate ocean tiles for lat/lon combinations not covered by HGT files
+    if args.lat_range is not None:
+        lat_min, lat_max = args.lat_range
+        ocean_work = []
+        idx = 0
+        for lat in range(lat_min, lat_max + 1):
+            for lon in range(-180, 180):
+                if (lat, lon) not in hgt_map:
+                    idx += 1
+                    ocean_work.append((lat, lon, args.output_dir, args.spacing,
+                                       "4.1", idx, None, args.overwrite))
+
+        # Fill in total count
+        ocean_total = len(ocean_work)
+        ocean_work = [(lat, lon, out, sp, fmt, i, ocean_total, ow)
+                      for lat, lon, out, sp, fmt, i, _, ow in ocean_work]
+
+        print(f"Generating {ocean_total} ocean tiles...")
+
+        if args.processes <= 1:
+            for wa in ocean_work:
+                process_ocean_tile(wa)
+        else:
+            with Pool(processes=args.processes) as pool:
+                pool.map(process_ocean_tile, ocean_work, chunksize=4)
 
     print("Done!")
 

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -174,48 +174,49 @@ def enumerate_valid_blocks(lat_int, lon_int, spacing, fmt):
     return valid_blocks, stride
 
 
-def compute_grid_points_vectorised(valid_blocks, spacing, fmt):
+def compute_grid_points_vectorised(valid_blocks, lat_int, lon_int, spacing, fmt):
     """Compute lat/lon coordinates for all grid points in all blocks.
 
     Returns (point_lat_e7, point_lon_e7) each with shape (n_blocks, 28, 32).
     The grid is 28 points north (gx) by 32 points east (gy), matching
     TERRAIN_GRID_BLOCK_SIZE_X=28, TERRAIN_GRID_BLOCK_SIZE_Y=32.
 
-    The original create_degree() converts block SW corners through a float
-    round-trip (int -> *1e-7 -> *1e7) before calling add_offset. This
-    introduces tiny float64 rounding errors that we must replicate exactly
-    for bit-identical output.
+    Uses a single-step offset from the degree corner for each grid point,
+    matching what AP_Terrain does on the vehicle. This avoids the two-step
+    error (degree corner -> block corner -> grid point) where compounding
+    longitude_scale at different latitudes causes horizontal drift at high
+    latitudes.
     """
     n_blocks = len(valid_blocks)
+    ref_lat = lat_int * 10 * 1000 * 1000  # degree corner in e7
+    ref_lon = lon_int * 10 * 1000 * 1000
 
-    # Block SW corners as integers
-    sw_lat_int = np.array([b[3] for b in valid_blocks], dtype=np.int64)
-    sw_lon_int = np.array([b[4] for b in valid_blocks], dtype=np.int64)
-
-    # Apply the same float round-trip as create_degree():
-    #   lat = lat_e7 * 1.0e-7;  add_offset(lat*1.0e7, ...)
-    sw_lat_f = sw_lat_int.astype(np.float64) * 1e-7 * 1e7  # (n_blocks,)
-    sw_lon_f = sw_lon_int.astype(np.float64) * 1e-7 * 1e7  # (n_blocks,)
+    # Grid indices for each block
+    block_grid_idx_x = np.array([b[1] for b in valid_blocks], dtype=np.int64)  # (n_blocks,)
+    block_grid_idx_y = np.array([b[2] for b in valid_blocks], dtype=np.int64)  # (n_blocks,)
 
     LSCF_INV = float(LOCATION_SCALING_FACTOR_INV)
 
-    # North offsets for gx: 0..27
-    gx_range = np.arange(TERRAIN_GRID_BLOCK_SIZE_X, dtype=np.float64)  # 28
-    north_m = gx_range * spacing
+    # Global grid indices (single-step from degree corner)
+    gx_range = np.arange(TERRAIN_GRID_BLOCK_SIZE_X, dtype=np.int64)  # 0..27
+    gy_range = np.arange(TERRAIN_GRID_BLOCK_SIZE_Y, dtype=np.int64)  # 0..31
 
-    # dlat = int(float(ofs_north) * LSCF_INV) — same for all blocks, shape (28,)
+    # North: global_idx_x = grid_idx_x * SPACING_X + gx, shape (n_blocks, 28)
+    global_idx_x = block_grid_idx_x[:, None] * TERRAIN_GRID_BLOCK_SPACING_X + gx_range[None, :]
+    north_m = global_idx_x.astype(np.float64) * spacing
+
+    # dlat = int(north_m * LSCF_INV), shape (n_blocks, 28)
     dlat = np.trunc(north_m * LSCF_INV).astype(np.int64)
 
-    # Point latitudes = int(sw_lat_f + dlat), shape (n_blocks, 28)
-    point_lat_e7 = np.trunc(sw_lat_f[:, None] + dlat[None, :].astype(np.float64)).astype(np.int64)
+    # Point latitudes: single-step from degree corner
+    point_lat_e7 = ref_lat + dlat  # (n_blocks, 28)
 
-    # East offsets for gy: 0..31
-    gy_range = np.arange(TERRAIN_GRID_BLOCK_SIZE_Y, dtype=np.float64)  # 32
-    east_m = gy_range * spacing
+    # East: global_idx_y = grid_idx_y * SPACING_Y + gy, shape (n_blocks, 32)
+    global_idx_y = block_grid_idx_y[:, None] * TERRAIN_GRID_BLOCK_SPACING_Y + gy_range[None, :]
+    east_m = global_idx_y.astype(np.float64) * spacing
 
-    # 4.1 format: longitude_scale uses midpoint (lat_e7 + dlat*0.5) * 1e-7
-    # where lat_e7 is sw_lat_f (the float round-tripped value)
-    mid_lat_deg = (sw_lat_f[:, None] + dlat[None, :].astype(np.float64) * 0.5) * 1e-7
+    # 4.1 format: longitude_scale uses midpoint (ref_lat + dlat*0.5) * 1e-7
+    mid_lat_deg = (float(ref_lat) + dlat.astype(np.float64) * 0.5) * 1e-7
     # (n_blocks, 28)
 
     # Match float32 behaviour for longitude_scale
@@ -223,11 +224,11 @@ def compute_grid_points_vectorised(valid_blocks, spacing, fmt):
     lon_scale = np.cos(rad_f32.astype(np.float64)).astype(np.float32).astype(np.float64)
     lon_scale = np.maximum(lon_scale, 0.01)  # (n_blocks, 28)
 
-    # dlng = int(float(ofs_east) * LSCF_INV / lon_scale), shape (n_blocks, 28, 32)
-    dlng = np.trunc(east_m[None, None, :] * LSCF_INV / lon_scale[:, :, None]).astype(np.int64)
+    # dlng = int(east_m * LSCF_INV / lon_scale), shape (n_blocks, 28, 32)
+    dlng = np.trunc(east_m[:, None, :] * LSCF_INV / lon_scale[:, :, None]).astype(np.int64)
 
-    # Point longitudes = int(sw_lon_f + dlng), shape (n_blocks, 28, 32)
-    point_lon_e7 = np.trunc(sw_lon_f[:, None, None] + dlng.astype(np.float64)).astype(np.int64)
+    # Point longitudes: single-step from degree corner
+    point_lon_e7 = ref_lon + dlng  # (n_blocks, 28, 32)
 
     # Expand lat to (n_blocks, 28, 32)
     point_lat_e7 = np.broadcast_to(point_lat_e7[:, :, None],
@@ -388,7 +389,7 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, til
         chunk_blocks = valid_blocks[chunk_start:chunk_end]
 
         point_lat_e7, point_lon_e7 = compute_grid_points_vectorised(
-            chunk_blocks, spacing, fmt)
+            chunk_blocks, lat_int, lon_int, spacing, fmt)
 
         # Step 4: Interpolate heights
         chunk_heights = interpolate_heights(

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -89,15 +89,12 @@ def load_hgt_zip(filepath):
     return arr
 
 
-def build_combined_array(lat_int, lon_int, hgt_map, hgt_cache):
-    """Build a combined elevation array covering the main tile and neighbours.
+def load_tile_dict(lat_int, lon_int, hgt_map, hgt_cache):
+    """Load the main tile and its neighbours into a dict.
 
-    Returns (combined_array, min_lat, min_lon, hgt_size).
-    The combined array covers a 2x2 degree area (or less if neighbours missing).
-    Row 0 = south, col 0 = west.
+    Returns (tile_dict, hgt_size) where tile_dict maps (lat, lon) to a
+    numpy array (row 0 = south), or None for missing/ocean tiles.
     """
-    # We need the main tile plus potentially tiles to the north and east
-    # (for edge blocks that interpolate across the degree boundary)
     needed = [
         (lat_int, lon_int),
         (lat_int, lon_int + 1),
@@ -105,7 +102,6 @@ def build_combined_array(lat_int, lon_int, hgt_map, hgt_cache):
         (lat_int + 1, lon_int + 1),
     ]
 
-    # Load needed tiles
     hgt_size = None
     for (lat, lon) in needed:
         if (lat, lon) in hgt_cache:
@@ -124,25 +120,9 @@ def build_combined_array(lat_int, lon_int, hgt_map, hgt_cache):
             hgt_cache[(lat, lon)] = None
 
     if hgt_size is None:
-        # No tiles at all - pure ocean
-        hgt_size = 3601  # default to SRTM1 size
-        # Return zeros
-        combined = np.zeros((2 * (hgt_size - 1) + 1, 2 * (hgt_size - 1) + 1), dtype=np.int16)
-        return combined, lat_int, lon_int, hgt_size
+        hgt_size = 3601
 
-    # Build combined array for 2x2 degree area
-    n = hgt_size - 1  # pixels per degree
-    combined = np.zeros((2 * n + 1, 2 * n + 1), dtype=np.int16)
-
-    for (lat, lon) in needed:
-        tile = hgt_cache.get((lat, lon))
-        if tile is None:
-            continue
-        row_offset = (lat - lat_int) * n
-        col_offset = (lon - lon_int) * n
-        combined[row_offset:row_offset + hgt_size, col_offset:col_offset + hgt_size] = tile
-
-    return combined, lat_int, lon_int, hgt_size
+    return hgt_cache, hgt_size
 
 
 def enumerate_valid_blocks(lat_int, lon_int, spacing, fmt):
@@ -257,52 +237,65 @@ def compute_grid_points_vectorised(valid_blocks, spacing, fmt):
     return point_lat_e7, point_lon_e7
 
 
-def interpolate_heights(point_lat_e7, point_lon_e7, combined, min_lat, min_lon, hgt_size):
-    """Bilinear interpolation of heights from the combined HGT array.
+def interpolate_heights(point_lat_e7, point_lon_e7, tile_dict, hgt_size):
+    """Bilinear interpolation of heights using per-tile lookup.
+
+    The original create_degree() selects a single SRTM tile per grid point
+    using floor(lat) and floor(lon), then interpolates within that tile.
+    SRTM tiles overlap by one pixel at boundaries and the overlap values
+    can disagree, so we must replicate this per-tile selection exactly.
 
     point_lat_e7, point_lon_e7: shape (n_blocks, 28, 32), int64
-    combined: the combined elevation array, row 0 = south at min_lat
+    tile_dict: {(lat_int, lon_int): numpy_array or None}
     Returns heights array shape (n_blocks, 28, 32), int16.
     """
     n = hgt_size - 1  # pixels per degree
+    shape = point_lat_e7.shape
+    heights = np.zeros(shape, dtype=np.int16)
 
-    # Convert to float pixel coordinates in the combined array
-    cy = (point_lat_e7.astype(np.float64) * 1e-7 - min_lat) * n
-    cx = (point_lon_e7.astype(np.float64) * 1e-7 - min_lon) * n
+    lat_deg = point_lat_e7.astype(np.float64) * 1e-7
+    lon_deg = point_lon_e7.astype(np.float64) * 1e-7
 
-    cy_int = np.floor(cy).astype(np.int32)
-    cx_int = np.floor(cx).astype(np.int32)
-    cy_frac = cy - cy_int
-    cx_frac = cx - cx_int
+    # Determine which tile each point belongs to
+    tile_lat = np.floor(lat_deg).astype(np.int32)
+    tile_lon = np.floor(lon_deg).astype(np.int32)
 
-    # Clamp to valid range
-    max_row = combined.shape[0] - 2
-    max_col = combined.shape[1] - 2
-    cy_int = np.clip(cy_int, 0, max_row)
-    cx_int = np.clip(cx_int, 0, max_col)
+    # Process each unique tile
+    unique_tiles = set(zip(tile_lat.ravel(), tile_lon.ravel()))
+    for (tlat, tlon) in unique_tiles:
+        tile = tile_dict.get((tlat, tlon))
+        if tile is None:
+            continue  # ocean / missing — heights stay 0
 
-    # Flatten for advanced indexing
-    flat_cy = cy_int.ravel()
-    flat_cx = cx_int.ravel()
-    shape = cy_int.shape
+        mask = (tile_lat == tlat) & (tile_lon == tlon)
+        if not np.any(mask):
+            continue
 
-    v00 = combined[flat_cy, flat_cx].reshape(shape).astype(np.float64)
-    v10 = combined[flat_cy, flat_cx + 1].reshape(shape).astype(np.float64)
-    v01 = combined[flat_cy + 1, flat_cx].reshape(shape).astype(np.float64)
-    v11 = combined[flat_cy + 1, flat_cx + 1].reshape(shape).astype(np.float64)
+        # Pixel coordinates within this tile
+        cy = (lat_deg[mask] - tlat) * n
+        cx = (lon_deg[mask] - tlon) * n
 
-    # Handle void values: the original code treats -1 (from getPixelValue) as None
-    # and uses _avg which skips None values. Since we replaced -32768 with 0 on load,
-    # this matches the original behaviour (void -> 0 altitude).
+        cy_int = np.floor(cy).astype(np.int32)
+        cx_int = np.floor(cx).astype(np.int32)
+        cy_frac = cy - cy_int
+        cx_frac = cx - cx_int
 
-    # Bilinear interpolation — two-step to match original scalar code exactly.
-    # The original does: interp x first, then interp y on the results.
-    # A single 4-point formula has different rounding and can be off-by-one.
-    val_x0 = v10 * cx_frac + v00 * (1 - cx_frac)  # y_int row
-    val_x1 = v11 * cx_frac + v01 * (1 - cx_frac)  # y_int+1 row
-    heights = val_x1 * cy_frac + val_x0 * (1 - cy_frac)
+        cy_int = np.clip(cy_int, 0, n - 1)
+        cx_int = np.clip(cx_int, 0, n - 1)
 
-    return heights.astype(np.int16)
+        v00 = tile[cy_int, cx_int].astype(np.float64)
+        v10 = tile[cy_int, cx_int + 1].astype(np.float64)
+        v01 = tile[cy_int + 1, cx_int].astype(np.float64)
+        v11 = tile[cy_int + 1, cx_int + 1].astype(np.float64)
+
+        # Two-step bilinear to match original scalar rounding exactly
+        val_x0 = v10 * cx_frac + v00 * (1 - cx_frac)
+        val_x1 = v11 * cx_frac + v01 * (1 - cx_frac)
+        val = val_x1 * cy_frac + val_x0 * (1 - cy_frac)
+
+        heights[mask] = val.astype(np.int16)
+
+    return heights
 
 
 def pack_dat_file(valid_blocks, heights, lat_int, lon_int, spacing, fmt):
@@ -378,8 +371,8 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
         print(f"No valid blocks for {os.path.basename(hgt_file)}")
         return
 
-    # Step 2: Build combined elevation array
-    combined, min_lat, min_lon, hgt_size = build_combined_array(
+    # Step 2: Load elevation tiles
+    tile_dict, hgt_size = load_tile_dict(
         lat_int, lon_int, hgt_map, hgt_cache)
 
     # Step 3: Compute grid point coordinates (vectorised, in chunks to limit memory)
@@ -397,7 +390,7 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
 
         # Step 4: Interpolate heights
         chunk_heights = interpolate_heights(
-            point_lat_e7, point_lon_e7, combined, min_lat, min_lon, hgt_size)
+            point_lat_e7, point_lon_e7, tile_dict, hgt_size)
 
         all_heights[chunk_start:chunk_end] = chunk_heights
 
@@ -436,8 +429,9 @@ def main():
     args = parser.parse_args()
 
     # Scan for HGT files (flat or continent subdirs)
-    hgt_files = sorted(glob.glob(os.path.join(args.hgt_dir, '**/*.hgt.zip'),
-                                 recursive=True))
+    hgt_files = sorted(f for f in glob.glob(os.path.join(args.hgt_dir, '**/*.hgt.zip'),
+                                            recursive=True)
+                        if parse_hgt_filename(f) is not None)
     if not hgt_files:
         print(f"No .hgt.zip files found in {args.hgt_dir}")
         sys.exit(1)

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -84,8 +84,8 @@ def load_hgt_zip(filepath):
     arr = np.frombuffer(data, dtype='>i2').reshape(size, size).astype(np.int16)
     # Flip so row 0 = south
     arr = arr[::-1].copy()
-    # Replace void values
-    arr[arr == -32768] = 0
+    # Replace void values with -1 to match srtm.py getPixelValue() behaviour
+    arr[arr == -32768] = -1
     return arr
 
 
@@ -349,7 +349,7 @@ def dat_filename(lat_int, lon_int):
                                      ew, min(abs(lon_int), 999))
 
 
-def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
+def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, tile_total=None):
     """Process a single HGT tile to produce a DAT.gz file."""
     coords = parse_hgt_filename(hgt_file)
     if coords is None:
@@ -359,8 +359,10 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
     lat_int, lon_int = coords
     outname = dat_filename(lat_int, lon_int)
     outpath = os.path.join(output_dir, outname)
+    progress = f"[{tile_idx}/{tile_total}] " if tile_idx is not None else ""
 
     if os.path.exists(outpath):
+        print(f"{progress}Skipping {outname} (exists)")
         return
 
     hgt_cache = {}
@@ -368,7 +370,7 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
     # Step 1: Enumerate valid blocks
     valid_blocks, stride = enumerate_valid_blocks(lat_int, lon_int, spacing, fmt)
     if not valid_blocks:
-        print(f"No valid blocks for {os.path.basename(hgt_file)}")
+        print(f"{progress}No valid blocks for {os.path.basename(hgt_file)}")
         return
 
     # Step 2: Load elevation tiles
@@ -404,7 +406,7 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
         f.write(file_buf)
     os.rename(tmp_path, outpath)
 
-    print(f"Generated {outname} ({n_blocks} blocks)")
+    print(f"{progress}Generated {outname} ({n_blocks} blocks)")
 
 
 def process_tile_wrapper(args):
@@ -429,40 +431,36 @@ def main():
     args = parser.parse_args()
 
     # Scan for HGT files (flat or continent subdirs)
-    hgt_files = sorted(f for f in glob.glob(os.path.join(args.hgt_dir, '**/*.hgt.zip'),
-                                            recursive=True)
-                        if parse_hgt_filename(f) is not None)
+    all_files = glob.glob(os.path.join(args.hgt_dir, '**/*.hgt.zip'), recursive=True)
+    hgt_files = []
+    for f in all_files:
+        coords = parse_hgt_filename(f)
+        if coords is not None:
+            hgt_files.append((coords, f))
+    # Sort by (lat, lon) for predictable processing order
+    hgt_files.sort(key=lambda x: x[0])
+
     if not hgt_files:
         print(f"No .hgt.zip files found in {args.hgt_dir}")
         sys.exit(1)
 
-    print(f"Found {len(hgt_files)} HGT files")
+    total = len(hgt_files)
+    print(f"Found {total} HGT files")
 
     # Build lookup dict: (lat, lon) -> filepath
-    hgt_map = {}
-    for f in hgt_files:
-        coords = parse_hgt_filename(f)
-        if coords is not None:
-            hgt_map[coords] = f
+    hgt_map = {coords: f for coords, f in hgt_files}
 
     os.makedirs(args.output_dir, exist_ok=True)
 
-    # Count how many already exist
-    existing = sum(1 for f in hgt_files
-                   if os.path.exists(os.path.join(args.output_dir,
-                                                  dat_filename(*parse_hgt_filename(f)))))
-    if existing > 0:
-        print(f"Skipping {existing} already-generated tiles")
-
-    work_args = [(f, hgt_map, args.output_dir, args.spacing, "4.1")
-                 for f in hgt_files]
+    work_args = [(f, hgt_map, args.output_dir, args.spacing, "4.1", i + 1, total)
+                 for i, (coords, f) in enumerate(hgt_files)]
 
     if args.processes <= 1:
         for wa in work_args:
             process_tile_wrapper(wa)
     else:
         with Pool(processes=args.processes) as pool:
-            pool.map(process_tile_wrapper, work_args)
+            pool.map(process_tile_wrapper, work_args, chunksize=1)
 
     print("Done!")
 

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""
+Fast HGT-to-DAT converter for ArduPilot terrain files.
+
+Replaces the slow offline_gen.py pipeline with numpy-vectorised conversion.
+Reads .hgt.zip files directly and produces .DAT.gz files.
+
+Usage:
+    python3 fast_gen.py <hgt_dir> <output_dir> [options]
+"""
+
+import argparse
+import glob
+import gzip
+import math
+import os
+import re
+import struct
+import sys
+import zipfile
+from multiprocessing import Pool
+
+import numpy as np
+import fastcrc
+
+from terrain_gen import (
+    add_offset,
+    east_blocks,
+    get_distance_NE_e7,
+    longitude_scale,
+    pos_from_file_offset,
+    to_float32,
+    IO_BLOCK_SIZE,
+    IO_BLOCK_DATA_SIZE,
+    IO_BLOCK_TRAILER_SIZE,
+    TERRAIN_GRID_BLOCK_SIZE_X,
+    TERRAIN_GRID_BLOCK_SIZE_Y,
+    TERRAIN_GRID_BLOCK_SPACING_X,
+    TERRAIN_GRID_BLOCK_SPACING_Y,
+    TERRAIN_GRID_FORMAT_VERSION,
+    LOCATION_SCALING_FACTOR,
+    LOCATION_SCALING_FACTOR_INV,
+    GridBlock,
+)
+
+BITMAP = (1 << 56) - 1
+
+# Filename pattern: N00E006.hgt.zip or S45W067.hgt.zip
+HGT_FILENAME_RE = re.compile(r'([NS])(\d{2})([EW])(\d{3})\.hgt\.zip$')
+
+
+def parse_hgt_filename(filepath):
+    """Parse lat/lon from an HGT filename. Returns (lat, lon) integers."""
+    basename = os.path.basename(filepath)
+    m = HGT_FILENAME_RE.match(basename)
+    if m is None:
+        return None
+    lat = int(m.group(2))
+    lon = int(m.group(4))
+    if m.group(1) == 'S':
+        lat = -lat
+    if m.group(3) == 'W':
+        lon = -lon
+    return (lat, lon)
+
+
+def load_hgt_zip(filepath):
+    """Load an HGT zip file and return elevation data as a numpy array.
+
+    Returns array with shape (size, size), row 0 = south, row N = north.
+    Values are int16. Void values (-32768) are replaced with 0.
+    """
+    with zipfile.ZipFile(filepath, 'r') as zf:
+        names = zf.namelist()
+        if len(names) != 1:
+            raise ValueError(f"Expected 1 file in zip, got {len(names)}: {filepath}")
+        data = zf.read(names[0])
+
+    size = int(math.sqrt(len(data) // 2))
+    if size not in (1201, 3601):
+        raise ValueError(f"Unexpected HGT size {size} in {filepath}")
+
+    # HGT files are big-endian int16, row 0 = north
+    arr = np.frombuffer(data, dtype='>i2').reshape(size, size).astype(np.int16)
+    # Flip so row 0 = south
+    arr = arr[::-1].copy()
+    # Replace void values
+    arr[arr == -32768] = 0
+    return arr
+
+
+def build_combined_array(lat_int, lon_int, hgt_map, hgt_cache):
+    """Build a combined elevation array covering the main tile and neighbours.
+
+    Returns (combined_array, min_lat, min_lon, hgt_size).
+    The combined array covers a 2x2 degree area (or less if neighbours missing).
+    Row 0 = south, col 0 = west.
+    """
+    # We need the main tile plus potentially tiles to the north and east
+    # (for edge blocks that interpolate across the degree boundary)
+    needed = [
+        (lat_int, lon_int),
+        (lat_int, lon_int + 1),
+        (lat_int + 1, lon_int),
+        (lat_int + 1, lon_int + 1),
+    ]
+
+    # Load needed tiles
+    hgt_size = None
+    for (lat, lon) in needed:
+        if (lat, lon) in hgt_cache:
+            if hgt_cache[(lat, lon)] is not None:
+                hgt_size = hgt_cache[(lat, lon)].shape[0]
+            continue
+        if (lat, lon) in hgt_map:
+            try:
+                arr = load_hgt_zip(hgt_map[(lat, lon)])
+                hgt_cache[(lat, lon)] = arr
+                hgt_size = arr.shape[0]
+            except Exception as e:
+                print(f"Warning: failed to load {hgt_map[(lat, lon)]}: {e}")
+                hgt_cache[(lat, lon)] = None
+        else:
+            hgt_cache[(lat, lon)] = None
+
+    if hgt_size is None:
+        # No tiles at all - pure ocean
+        hgt_size = 3601  # default to SRTM1 size
+        # Return zeros
+        combined = np.zeros((2 * (hgt_size - 1) + 1, 2 * (hgt_size - 1) + 1), dtype=np.int16)
+        return combined, lat_int, lon_int, hgt_size
+
+    # Build combined array for 2x2 degree area
+    n = hgt_size - 1  # pixels per degree
+    combined = np.zeros((2 * n + 1, 2 * n + 1), dtype=np.int16)
+
+    for (lat, lon) in needed:
+        tile = hgt_cache.get((lat, lon))
+        if tile is None:
+            continue
+        row_offset = (lat - lat_int) * n
+        col_offset = (lon - lon_int) * n
+        combined[row_offset:row_offset + hgt_size, col_offset:col_offset + hgt_size] = tile
+
+    return combined, lat_int, lon_int, hgt_size
+
+
+def enumerate_valid_blocks(lat_int, lon_int, spacing, fmt):
+    """Enumerate all valid blocks for a 1-degree tile.
+
+    Returns list of (blocknum, grid_idx_x, grid_idx_y, lat_e7, lon_e7).
+    """
+    ref_lat = lat_int * 10 * 1000 * 1000
+    ref_lon = lon_int * 10 * 1000 * 1000
+    stride = east_blocks(ref_lat, ref_lon, spacing, fmt)
+
+    valid_blocks = []
+    blocknum = -1
+
+    while True:
+        blocknum += 1
+        (lat_e7, lon_e7) = pos_from_file_offset(lat_int, lon_int,
+                                                  blocknum * IO_BLOCK_SIZE,
+                                                  spacing, fmt)
+        if lat_e7 * 1.0e-7 - lat_int >= 1.0:
+            break
+
+        # Validate round-trip: compute grid indices and check blocknum matches
+        grid_idx_x = blocknum // stride
+        grid_idx_y = blocknum % stride
+
+        # Recompute position from grid indices (same as GridBlock.__init__)
+        idx_x = grid_idx_x * TERRAIN_GRID_BLOCK_SPACING_X
+        idx_y = grid_idx_y * TERRAIN_GRID_BLOCK_SPACING_Y
+
+        (check_lat, check_lon) = add_offset(
+            ref_lat, ref_lon,
+            idx_x * float(spacing),
+            idx_y * float(spacing),
+            fmt
+        )
+
+        # Compute offset back and verify block number
+        offset = get_distance_NE_e7(ref_lat, ref_lon, check_lat, check_lon, fmt)
+        check_idx_x = int(round(offset[0]) / spacing) // TERRAIN_GRID_BLOCK_SPACING_X
+        check_idx_y = int(round(offset[1]) / spacing) // TERRAIN_GRID_BLOCK_SPACING_Y
+        check_blocknum = stride * check_idx_x + check_idx_y
+
+        if check_blocknum != blocknum:
+            continue
+
+        valid_blocks.append((blocknum, grid_idx_x, grid_idx_y, check_lat, check_lon))
+
+    return valid_blocks, stride
+
+
+def compute_grid_points_vectorised(valid_blocks, spacing, fmt):
+    """Compute lat/lon coordinates for all grid points in all blocks.
+
+    Returns (point_lat_e7, point_lon_e7) each with shape (n_blocks, 28, 32).
+    The grid is 28 points north (gx) by 32 points east (gy), matching
+    TERRAIN_GRID_BLOCK_SIZE_X=28, TERRAIN_GRID_BLOCK_SIZE_Y=32.
+
+    The original create_degree() converts block SW corners through a float
+    round-trip (int -> *1e-7 -> *1e7) before calling add_offset. This
+    introduces tiny float64 rounding errors that we must replicate exactly
+    for bit-identical output.
+    """
+    n_blocks = len(valid_blocks)
+
+    # Block SW corners as integers
+    sw_lat_int = np.array([b[3] for b in valid_blocks], dtype=np.int64)
+    sw_lon_int = np.array([b[4] for b in valid_blocks], dtype=np.int64)
+
+    # Apply the same float round-trip as create_degree():
+    #   lat = lat_e7 * 1.0e-7;  add_offset(lat*1.0e7, ...)
+    sw_lat_f = sw_lat_int.astype(np.float64) * 1e-7 * 1e7  # (n_blocks,)
+    sw_lon_f = sw_lon_int.astype(np.float64) * 1e-7 * 1e7  # (n_blocks,)
+
+    LSCF_INV = float(LOCATION_SCALING_FACTOR_INV)
+
+    # North offsets for gx: 0..27
+    gx_range = np.arange(TERRAIN_GRID_BLOCK_SIZE_X, dtype=np.float64)  # 28
+    north_m = gx_range * spacing
+
+    # dlat = int(float(ofs_north) * LSCF_INV) — same for all blocks, shape (28,)
+    dlat = np.trunc(north_m * LSCF_INV).astype(np.int64)
+
+    # Point latitudes = int(sw_lat_f + dlat), shape (n_blocks, 28)
+    point_lat_e7 = np.trunc(sw_lat_f[:, None] + dlat[None, :].astype(np.float64)).astype(np.int64)
+
+    # East offsets for gy: 0..31
+    gy_range = np.arange(TERRAIN_GRID_BLOCK_SIZE_Y, dtype=np.float64)  # 32
+    east_m = gy_range * spacing
+
+    # 4.1 format: longitude_scale uses midpoint (lat_e7 + dlat*0.5) * 1e-7
+    # where lat_e7 is sw_lat_f (the float round-tripped value)
+    mid_lat_deg = (sw_lat_f[:, None] + dlat[None, :].astype(np.float64) * 0.5) * 1e-7
+    # (n_blocks, 28)
+
+    # Match float32 behaviour for longitude_scale
+    rad_f32 = np.radians(mid_lat_deg).astype(np.float32)
+    lon_scale = np.cos(rad_f32.astype(np.float64)).astype(np.float32).astype(np.float64)
+    lon_scale = np.maximum(lon_scale, 0.01)  # (n_blocks, 28)
+
+    # dlng = int(float(ofs_east) * LSCF_INV / lon_scale), shape (n_blocks, 28, 32)
+    dlng = np.trunc(east_m[None, None, :] * LSCF_INV / lon_scale[:, :, None]).astype(np.int64)
+
+    # Point longitudes = int(sw_lon_f + dlng), shape (n_blocks, 28, 32)
+    point_lon_e7 = np.trunc(sw_lon_f[:, None, None] + dlng.astype(np.float64)).astype(np.int64)
+
+    # Expand lat to (n_blocks, 28, 32)
+    point_lat_e7 = np.broadcast_to(point_lat_e7[:, :, None],
+                                    (n_blocks, TERRAIN_GRID_BLOCK_SIZE_X,
+                                     TERRAIN_GRID_BLOCK_SIZE_Y)).copy()
+
+    return point_lat_e7, point_lon_e7
+
+
+def interpolate_heights(point_lat_e7, point_lon_e7, combined, min_lat, min_lon, hgt_size):
+    """Bilinear interpolation of heights from the combined HGT array.
+
+    point_lat_e7, point_lon_e7: shape (n_blocks, 28, 32), int64
+    combined: the combined elevation array, row 0 = south at min_lat
+    Returns heights array shape (n_blocks, 28, 32), int16.
+    """
+    n = hgt_size - 1  # pixels per degree
+
+    # Convert to float pixel coordinates in the combined array
+    cy = (point_lat_e7.astype(np.float64) * 1e-7 - min_lat) * n
+    cx = (point_lon_e7.astype(np.float64) * 1e-7 - min_lon) * n
+
+    cy_int = np.floor(cy).astype(np.int32)
+    cx_int = np.floor(cx).astype(np.int32)
+    cy_frac = cy - cy_int
+    cx_frac = cx - cx_int
+
+    # Clamp to valid range
+    max_row = combined.shape[0] - 2
+    max_col = combined.shape[1] - 2
+    cy_int = np.clip(cy_int, 0, max_row)
+    cx_int = np.clip(cx_int, 0, max_col)
+
+    # Flatten for advanced indexing
+    flat_cy = cy_int.ravel()
+    flat_cx = cx_int.ravel()
+    shape = cy_int.shape
+
+    v00 = combined[flat_cy, flat_cx].reshape(shape).astype(np.float64)
+    v10 = combined[flat_cy, flat_cx + 1].reshape(shape).astype(np.float64)
+    v01 = combined[flat_cy + 1, flat_cx].reshape(shape).astype(np.float64)
+    v11 = combined[flat_cy + 1, flat_cx + 1].reshape(shape).astype(np.float64)
+
+    # Handle void values: the original code treats -1 (from getPixelValue) as None
+    # and uses _avg which skips None values. Since we replaced -32768 with 0 on load,
+    # this matches the original behaviour (void -> 0 altitude).
+
+    # Bilinear interpolation — two-step to match original scalar code exactly.
+    # The original does: interp x first, then interp y on the results.
+    # A single 4-point formula has different rounding and can be off-by-one.
+    val_x0 = v10 * cx_frac + v00 * (1 - cx_frac)  # y_int row
+    val_x1 = v11 * cx_frac + v01 * (1 - cx_frac)  # y_int+1 row
+    heights = val_x1 * cy_frac + val_x0 * (1 - cy_frac)
+
+    return heights.astype(np.int16)
+
+
+def pack_dat_file(valid_blocks, heights, lat_int, lon_int, spacing, fmt):
+    """Pack all blocks into a DAT file buffer.
+
+    valid_blocks: list of (blocknum, grid_idx_x, grid_idx_y, lat_e7, lon_e7)
+    heights: shape (n_blocks, 28, 32) int16
+    Returns bytes.
+    """
+    if not valid_blocks:
+        return b''
+
+    max_blocknum = max(b[0] for b in valid_blocks)
+    file_buf = bytearray((max_blocknum + 1) * IO_BLOCK_SIZE)
+
+    for i, (blocknum, grid_idx_x, grid_idx_y, blk_lat, blk_lon) in enumerate(valid_blocks):
+        # Build block with crc=0 first
+        header = struct.pack('<QiiHHH', BITMAP, int(blk_lat), int(blk_lon),
+                             0, TERRAIN_GRID_FORMAT_VERSION, spacing)
+
+        # Heights for this block: shape (28, 32), pack as little-endian int16
+        # The original packs gx rows sequentially, each row being 32 int16 values
+        h_block = heights[i]  # (28, 32)
+        h_bytes = h_block.astype('<i2').tobytes()
+
+        # Trailer: grid_idx_x (H), grid_idx_y (H), lon_degrees (h), lat_degrees (b)
+        trailer = struct.pack('<HHhb', grid_idx_x, grid_idx_y, lon_int, lat_int)
+
+        # Assemble block: header(22) + heights(1792) + trailer(7) = 1821 data bytes
+        # Plus padding to fill IO_BLOCK_SIZE
+        block = header + h_bytes + trailer
+        padding_size = IO_BLOCK_SIZE - len(block)
+        block = block + b'\x00' * padding_size
+
+        # Compute CRC over first 1821 bytes (with crc field = 0)
+        crc = fastcrc.crc16.xmodem(block[:IO_BLOCK_DATA_SIZE])
+
+        # Patch CRC into the block (at offset 16, 2 bytes)
+        block = block[:16] + struct.pack('<H', crc) + block[18:]
+
+        file_buf[blocknum * IO_BLOCK_SIZE:(blocknum + 1) * IO_BLOCK_SIZE] = block
+
+    return bytes(file_buf)
+
+
+def dat_filename(lat_int, lon_int):
+    """Generate the DAT filename for a lat/lon pair."""
+    ns = 'S' if lat_int < 0 else 'N'
+    ew = 'W' if lon_int < 0 else 'E'
+    return "%c%02u%c%03u.DAT.gz" % (ns, min(abs(lat_int), 99),
+                                     ew, min(abs(lon_int), 999))
+
+
+def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt):
+    """Process a single HGT tile to produce a DAT.gz file."""
+    coords = parse_hgt_filename(hgt_file)
+    if coords is None:
+        print(f"Skipping unrecognised file: {hgt_file}")
+        return
+
+    lat_int, lon_int = coords
+    outname = dat_filename(lat_int, lon_int)
+    outpath = os.path.join(output_dir, outname)
+
+    if os.path.exists(outpath):
+        return
+
+    hgt_cache = {}
+
+    # Step 1: Enumerate valid blocks
+    valid_blocks, stride = enumerate_valid_blocks(lat_int, lon_int, spacing, fmt)
+    if not valid_blocks:
+        print(f"No valid blocks for {os.path.basename(hgt_file)}")
+        return
+
+    # Step 2: Build combined elevation array
+    combined, min_lat, min_lon, hgt_size = build_combined_array(
+        lat_int, lon_int, hgt_map, hgt_cache)
+
+    # Step 3: Compute grid point coordinates (vectorised, in chunks to limit memory)
+    CHUNK_SIZE = 2000
+    n_blocks = len(valid_blocks)
+    all_heights = np.zeros((n_blocks, TERRAIN_GRID_BLOCK_SIZE_X,
+                            TERRAIN_GRID_BLOCK_SIZE_Y), dtype=np.int16)
+
+    for chunk_start in range(0, n_blocks, CHUNK_SIZE):
+        chunk_end = min(chunk_start + CHUNK_SIZE, n_blocks)
+        chunk_blocks = valid_blocks[chunk_start:chunk_end]
+
+        point_lat_e7, point_lon_e7 = compute_grid_points_vectorised(
+            chunk_blocks, spacing, fmt)
+
+        # Step 4: Interpolate heights
+        chunk_heights = interpolate_heights(
+            point_lat_e7, point_lon_e7, combined, min_lat, min_lon, hgt_size)
+
+        all_heights[chunk_start:chunk_end] = chunk_heights
+
+    # Step 5: Pack into DAT file buffer
+    file_buf = pack_dat_file(valid_blocks, all_heights, lat_int, lon_int, spacing, fmt)
+
+    # Step 6: Compress and write atomically
+    os.makedirs(output_dir, exist_ok=True)
+    tmp_path = outpath + '.tmp'
+    with gzip.open(tmp_path, 'wb') as f:
+        f.write(file_buf)
+    os.rename(tmp_path, outpath)
+
+    print(f"Generated {outname} ({n_blocks} blocks)")
+
+
+def process_tile_wrapper(args):
+    """Wrapper for multiprocessing that unpacks arguments."""
+    try:
+        process_tile(*args)
+    except Exception as e:
+        print(f"Error processing {args[0]}: {e}")
+        import traceback
+        traceback.print_exc()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Fast HGT-to-DAT converter for ArduPilot terrain files')
+    parser.add_argument('hgt_dir', help='Directory containing .hgt.zip files')
+    parser.add_argument('output_dir', help='Output directory for .DAT.gz files')
+    parser.add_argument('--spacing', type=int, default=30, choices=[30, 100],
+                        help='Grid spacing in metres (default: 30)')
+    parser.add_argument('--processes', type=int, default=8,
+                        help='Number of parallel workers (default: 8)')
+    args = parser.parse_args()
+
+    # Scan for HGT files (flat or continent subdirs)
+    hgt_files = sorted(glob.glob(os.path.join(args.hgt_dir, '**/*.hgt.zip'),
+                                 recursive=True))
+    if not hgt_files:
+        print(f"No .hgt.zip files found in {args.hgt_dir}")
+        sys.exit(1)
+
+    print(f"Found {len(hgt_files)} HGT files")
+
+    # Build lookup dict: (lat, lon) -> filepath
+    hgt_map = {}
+    for f in hgt_files:
+        coords = parse_hgt_filename(f)
+        if coords is not None:
+            hgt_map[coords] = f
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    # Count how many already exist
+    existing = sum(1 for f in hgt_files
+                   if os.path.exists(os.path.join(args.output_dir,
+                                                  dat_filename(*parse_hgt_filename(f)))))
+    if existing > 0:
+        print(f"Skipping {existing} already-generated tiles")
+
+    work_args = [(f, hgt_map, args.output_dir, args.spacing, "4.1")
+                 for f in hgt_files]
+
+    if args.processes <= 1:
+        for wa in work_args:
+            process_tile_wrapper(wa)
+    else:
+        with Pool(processes=args.processes) as pool:
+            pool.map(process_tile_wrapper, work_args)
+
+    print("Done!")
+
+
+if __name__ == '__main__':
+    main()

--- a/fast_gen.py
+++ b/fast_gen.py
@@ -402,9 +402,11 @@ def process_tile(hgt_file, hgt_map, output_dir, spacing, fmt, tile_idx=None, til
 
     # Step 6: Compress and write atomically
     os.makedirs(output_dir, exist_ok=True)
+    dat_name = outname[:-3]  # .DAT name for gzip header
     tmp_path = outpath + '.tmp'
-    with gzip.open(tmp_path, 'wb') as f:
-        f.write(file_buf)
+    with open(tmp_path, 'wb') as raw_f:
+        with gzip.GzipFile(dat_name, 'wb', fileobj=raw_f) as f:
+            f.write(file_buf)
     os.rename(tmp_path, outpath)
 
     print(f"{progress}Generated {outname} ({n_blocks} blocks)")

--- a/find_steep.py
+++ b/find_steep.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+'''Find terrain files with steep height differences between neighbouring points.'''
+
+import argparse
+import glob
+import gzip
+import math
+import os
+import re
+import struct
+import sys
+import zipfile
+from multiprocessing import Pool
+
+import numpy as np
+
+IO_BLOCK_SIZE = 2048
+TERRAIN_GRID_BLOCK_SIZE_X = 28
+TERRAIN_GRID_BLOCK_SIZE_Y = 32
+
+TILE_RE = re.compile(r'([NS])(\d{2})([EW])(\d{3})')
+
+
+def file_type(filepath):
+    name = filepath.lower()
+    if name.endswith('.hgt.zip'):
+        return 'hgt'
+    if name.endswith('.dat.gz') or name.endswith('.dat'):
+        return 'dat'
+    return None
+
+
+def parse_tile_coords(filepath):
+    m = TILE_RE.search(os.path.basename(filepath))
+    if m is None:
+        return None
+    lat = int(m.group(2))
+    lon = int(m.group(4))
+    if m.group(1) == 'S':
+        lat = -lat
+    if m.group(3) == 'W':
+        lon = -lon
+    return (lat, lon)
+
+
+def scan_hgt(args):
+    filepath, threshold = args
+    basename = os.path.basename(filepath)
+    try:
+        coords = parse_tile_coords(filepath)
+        tile_lat, tile_lon = coords if coords else (0, 0)
+
+        with zipfile.ZipFile(filepath, 'r') as zf:
+            data = zf.read(zf.namelist()[0])
+        size = int(math.sqrt(len(data) // 2))
+        n = size - 1
+        arr = np.frombuffer(data, dtype='>i2').reshape(size, size).astype(np.float32)
+        # Mark voids as NaN so they don't trigger false positives
+        arr[arr == -32768] = np.nan
+
+        # Check horizontal and vertical neighbours
+        diff_h = np.abs(np.diff(arr, axis=1))
+        diff_v = np.abs(np.diff(arr, axis=0))
+
+        steep_h = np.nansum(diff_h > threshold)
+        steep_v = np.nansum(diff_v > threshold)
+
+        # Find location of max difference
+        max_h = np.nanmax(diff_h) if diff_h.size > 0 else 0
+        max_v = np.nanmax(diff_v) if diff_v.size > 0 else 0
+        if max_h >= max_v and max_h > 0:
+            idx = np.nanargmax(diff_h)
+            row, col = divmod(idx, diff_h.shape[1])
+        elif max_v > 0:
+            idx = np.nanargmax(diff_v)
+            row, col = divmod(idx, diff_v.shape[1])
+        else:
+            row, col = 0, 0
+        max_diff = max(max_h, max_v)
+
+        # HGT layout: row 0 = north, col = east. Pixel (row, col) -> lat/lon
+        max_lat = tile_lat + 1.0 - row / n
+        max_lon = tile_lon + col / n
+
+        total = int(steep_h + steep_v)
+        return (basename, total, float(max_diff), max_lat, max_lon, None)
+    except Exception as e:
+        return (basename, 0, 0, 0, 0, str(e))
+
+
+def scan_dat(args):
+    filepath, threshold = args
+    basename = os.path.basename(filepath)
+    try:
+        if filepath.endswith('.gz'):
+            with gzip.open(filepath, 'rb') as f:
+                data = f.read()
+        else:
+            with open(filepath, 'rb') as f:
+                data = f.read()
+
+        total_steep = 0
+        max_diff = 0.0
+        max_lat = 0.0
+        max_lon = 0.0
+        num_blocks = len(data) // IO_BLOCK_SIZE
+
+        for i in range(num_blocks):
+            block = data[i * IO_BLOCK_SIZE:(i + 1) * IO_BLOCK_SIZE]
+            bitmap, blk_lat, blk_lon, crc, version, spacing = struct.unpack("<QiiHHH", block[:22])
+            if version == 0 and spacing == 0:
+                continue
+
+            # Parse heights into numpy array (28 rows x 32 cols)
+            offset = 22
+            h = np.frombuffer(block[offset:offset + TERRAIN_GRID_BLOCK_SIZE_X * TERRAIN_GRID_BLOCK_SIZE_Y * 2],
+                              dtype='<i2').reshape(TERRAIN_GRID_BLOCK_SIZE_X, TERRAIN_GRID_BLOCK_SIZE_Y).astype(np.float32)
+
+            diff_h = np.abs(np.diff(h, axis=1))
+            diff_v = np.abs(np.diff(h, axis=0))
+
+            steep_h = np.sum(diff_h > threshold)
+            steep_v = np.sum(diff_v > threshold)
+            total_steep += int(steep_h + steep_v)
+
+            blk_max_h = np.max(diff_h) if diff_h.size > 0 else 0
+            blk_max_v = np.max(diff_v) if diff_v.size > 0 else 0
+            blk_max = max(blk_max_h, blk_max_v)
+            if blk_max > max_diff:
+                max_diff = float(blk_max)
+                # Block lat/lon is SW corner in 1e7, spacing in metres
+                # gx = north index, gy = east index
+                if blk_max_h >= blk_max_v:
+                    idx = np.argmax(diff_h)
+                    gx, gy = divmod(idx, diff_h.shape[1])
+                else:
+                    idx = np.argmax(diff_v)
+                    gx, gy = divmod(idx, diff_v.shape[1])
+                max_lat = blk_lat * 1e-7 + gx * spacing / 111111.0
+                max_lon = blk_lon * 1e-7 + gy * spacing / (111111.0 * max(math.cos(math.radians(blk_lat * 1e-7)), 0.01))
+
+        return (basename, total_steep, max_diff, max_lat, max_lon, None)
+    except Exception as e:
+        return (basename, 0, 0, 0, 0, str(e))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Find terrain files with steep height differences between neighbours')
+    parser.add_argument('paths', nargs='+',
+                        help='Directories and/or individual .hgt.zip / .DAT.gz files')
+    parser.add_argument('--threshold', type=float, default=1000,
+                        help='Height difference threshold in metres (default: 1000)')
+    parser.add_argument('--processes', type=int, default=8,
+                        help='Number of parallel workers')
+    parser.add_argument('-o', type=str, default=None,
+                        help='Save report to file')
+    args = parser.parse_args()
+
+    files = []
+    for path in args.paths:
+        if os.path.isdir(path):
+            for f in glob.glob(os.path.join(path, '**/*.hgt.zip'), recursive=True):
+                files.append(f)
+            for f in glob.glob(os.path.join(path, '**/*.DAT.gz'), recursive=True):
+                files.append(f)
+            for f in glob.glob(os.path.join(path, '**/*.DAT'), recursive=True):
+                if not f.endswith('.DAT.gz'):
+                    files.append(f)
+        elif os.path.isfile(path):
+            files.append(path)
+    files.sort()
+
+    if not files:
+        print("No terrain files found")
+        sys.exit(1)
+
+    hgt_work = [(f, args.threshold) for f in files if file_type(f) == 'hgt']
+    dat_work = [(f, args.threshold) for f in files if file_type(f) == 'dat']
+
+    print("Scanning %d HGT + %d DAT files, threshold=%gm, %d processes..." % (
+        len(hgt_work), len(dat_work), args.threshold, args.processes))
+
+    results = []
+    with Pool(processes=args.processes) as pool:
+        scanned = 0
+        total = len(hgt_work) + len(dat_work)
+        if hgt_work:
+            for r in pool.imap_unordered(scan_hgt, hgt_work, chunksize=16):
+                scanned += 1
+                results.append(r)
+                if scanned % 1000 == 0:
+                    print("  %d / %d" % (scanned, total))
+        if dat_work:
+            for r in pool.imap_unordered(scan_dat, dat_work, chunksize=16):
+                scanned += 1
+                results.append(r)
+                if scanned % 1000 == 0:
+                    print("  %d / %d" % (scanned, total))
+
+    results.sort(key=lambda x: x[0])
+
+    steep = [(name, count, maxd, lat, lon) for name, count, maxd, lat, lon, err in results if count > 0 and err is None]
+    errors = [(name, err) for name, _, _, _, _, err in results if err is not None]
+
+    # Sort by max difference descending
+    steep.sort(key=lambda x: -x[2])
+
+    lines = []
+    lines.append("=== Steep terrain report (threshold=%gm) ===" % args.threshold)
+    lines.append("Files scanned: %d" % len(results))
+    lines.append("Files exceeding threshold: %d" % len(steep))
+    lines.append("")
+
+    if steep:
+        lines.append("%-30s %8s %8s  %s" % ("File", "Count", "Max(m)", "Max location"))
+        lines.append("-" * 72)
+        for name, count, maxd, lat, lon in steep:
+            lines.append("%-30s %8d %8.0f  %.4f,%.4f" % (name, count, maxd, lat, lon))
+        lines.append("")
+
+    if errors:
+        lines.append("Errors: %d" % len(errors))
+        for name, err in errors:
+            lines.append("  %s: %s" % (name, err))
+
+    report = "\n".join(lines)
+    print(report)
+
+    if args.o:
+        with open(args.o, 'w') as f:
+            f.write(report + "\n")
+        print("\nReport written to %s" % args.o)
+
+
+if __name__ == '__main__':
+    main()

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -233,6 +233,21 @@ def log_regen(message):
         regen_log_file.write(message + "\n")
         regen_log_file.flush()
 
+def files_are_identical(dat_file, gz_backup_file):
+    """Compare a .DAT file with a .gz backup file.
+
+    Returns True if the contents are identical, False otherwise.
+    """
+    try:
+        with open(dat_file, 'rb') as f:
+            new_data = f.read()
+        with gzip.open(gz_backup_file, 'rb') as f:
+            old_data = f.read()
+        return new_data == old_data
+    except Exception as e:
+        print(f"Error comparing files: {e}")
+        return False
+
 def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, spacing, regen_ocean=False, regen_list=False):
     gz_file = datafile(lat, long, targetFolder) + '.gz'
     dat_file = datafile(lat, long, targetFolder)
@@ -291,6 +306,15 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
         print("Created tile {0} of {1}".format(startedTiles, totTiles))
     else:
         print("Skipping existing tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+
+    # Check if new file is identical to backup before compressing
+    if backup_file and os.path.exists(backup_file):
+        if files_are_identical(dat_file, backup_file):
+            print("Identical tile {0} of {1}: {2}".format(
+                startedTiles+1, totTiles, os.path.basename(gz_file)))
+            os.remove(dat_file)
+            os.rename(backup_file, gz_file)
+            return
 
     # and compress
     with open(dat_file, 'rb') as f_in:

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -294,37 +294,47 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
             print("Skipping existing compressed tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
             return
 
-    if not os.path.exists(dat_file):
-        if not create_degree(downloader, lat, long, targetFolder, spacing, format):
-            #print("Skipping not downloaded tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
-            # Restore backup if regeneration failed
-            if backup_file and os.path.exists(backup_file):
+    try:
+        if not os.path.exists(dat_file):
+            if not create_degree(downloader, lat, long, targetFolder, spacing, format):
+                #print("Skipping not downloaded tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+                # Restore backup if regeneration failed
+                if backup_file and os.path.exists(backup_file):
+                    os.rename(backup_file, gz_file)
+                    print("Regeneration failed, restored backup: {0}".format(os.path.basename(gz_file)))
+                time.sleep(0.2)
+                return
+            print("Created tile {0} of {1}".format(startedTiles, totTiles))
+        else:
+            print("Skipping existing tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+
+        # Check if new file is identical to backup before compressing
+        if backup_file and os.path.exists(backup_file):
+            if files_are_identical(dat_file, backup_file):
+                print("Identical tile {0} of {1}: {2}".format(
+                    startedTiles+1, totTiles, os.path.basename(gz_file)))
+                os.remove(dat_file)
                 os.rename(backup_file, gz_file)
-                print("Regeneration failed, restored backup: {0}".format(os.path.basename(gz_file)))
-            time.sleep(0.2)
-            return
-        print("Created tile {0} of {1}".format(startedTiles, totTiles))
-    else:
-        print("Skipping existing tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+                return
 
-    # Check if new file is identical to backup before compressing
-    if backup_file and os.path.exists(backup_file):
-        if files_are_identical(dat_file, backup_file):
-            print("Identical tile {0} of {1}: {2}".format(
-                startedTiles+1, totTiles, os.path.basename(gz_file)))
-            os.remove(dat_file)
-            os.rename(backup_file, gz_file)
-            return
+        # and compress
+        with open(dat_file, 'rb') as f_in:
+            with gzip.open(gz_file, 'wb') as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        os.remove(dat_file)
 
-    # and compress
-    with open(dat_file, 'rb') as f_in:
-        with gzip.open(gz_file, 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
-    os.remove(dat_file)
-
-    # Remove backup after successful regeneration
-    if backup_file and os.path.exists(backup_file):
-        os.remove(backup_file)
+        # Remove backup after successful regeneration
+        if backup_file and os.path.exists(backup_file):
+            os.remove(backup_file)
+    except Exception as e:
+        # Always restore backup on any error
+        if backup_file and os.path.exists(backup_file):
+            if not os.path.exists(gz_file):
+                os.rename(backup_file, gz_file)
+                print("Exception occurred, restored backup: {0} ({1})".format(os.path.basename(gz_file), e))
+            else:
+                os.remove(backup_file)
+        raise
 
     # Log comparison for --regen-ocean mode
     if regen_ocean and old_heights is not None:

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -233,15 +233,15 @@ def log_regen(message):
         regen_log_file.write(message + "\n")
         regen_log_file.flush()
 
-def files_are_identical(dat_file, gz_backup_file):
-    """Compare a .DAT file with a .gz backup file.
+def files_are_identical(dat_file, gz_file):
+    """Compare a .DAT file with an existing .gz file.
 
     Returns True if the contents are identical, False otherwise.
     """
     try:
         with open(dat_file, 'rb') as f:
             new_data = f.read()
-        with gzip.open(gz_backup_file, 'rb') as f:
+        with gzip.open(gz_file, 'rb') as f:
             old_data = f.read()
         return new_data == old_data
     except Exception as e:
@@ -251,8 +251,8 @@ def files_are_identical(dat_file, gz_backup_file):
 def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, spacing, regen_ocean=False, regen_list=False):
     gz_file = datafile(lat, long, targetFolder) + '.gz'
     dat_file = datafile(lat, long, targetFolder)
+    tmp_gz_file = gz_file + '.tmp'
     old_heights = None
-    backup_file = None
 
     # Check if we need to regenerate due to ocean tile bug
     if regen_ocean:
@@ -260,11 +260,8 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
             if is_tile_affected(gz_file):
                 print("Regenerating ocean-bug-affected tile {0} of {1}: {2}".format(
                     startedTiles+1, totTiles, os.path.basename(gz_file)))
-                # Read old heights for comparison (don't delete yet!)
+                # Read old heights for comparison logging
                 old_heights = read_tile_heights(gz_file)
-                # Rename to backup - only delete after successful regeneration
-                backup_file = gz_file + '.bak'
-                os.rename(gz_file, backup_file)
             else:
                 # Tile is not affected, skip it
                 return
@@ -276,9 +273,6 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
         if os.path.exists(gz_file):
             print("Regenerating from list tile {0} of {1}: {2}".format(
                 startedTiles+1, totTiles, os.path.basename(gz_file)))
-            # Rename to backup - only delete after successful regeneration
-            backup_file = gz_file + '.bak'
-            os.rename(gz_file, backup_file)
         elif os.path.exists(dat_file):
             print("Regenerating from list tile {0} of {1}: {2}".format(
                 startedTiles+1, totTiles, os.path.basename(dat_file)))
@@ -294,47 +288,31 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
             print("Skipping existing compressed tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
             return
 
-    try:
-        if not os.path.exists(dat_file):
-            if not create_degree(downloader, lat, long, targetFolder, spacing, format):
-                #print("Skipping not downloaded tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
-                # Restore backup if regeneration failed
-                if backup_file and os.path.exists(backup_file):
-                    os.rename(backup_file, gz_file)
-                    print("Regeneration failed, restored backup: {0}".format(os.path.basename(gz_file)))
-                time.sleep(0.2)
-                return
-            print("Created tile {0} of {1}".format(startedTiles, totTiles))
-        else:
-            print("Skipping existing tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+    # Generate the new tile
+    if not os.path.exists(dat_file):
+        if not create_degree(downloader, lat, long, targetFolder, spacing, format):
+            time.sleep(0.2)
+            return
+        print("Created tile {0} of {1}".format(startedTiles, totTiles))
+    else:
+        print("Skipping existing tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
 
-        # Check if new file is identical to backup before compressing
-        if backup_file and os.path.exists(backup_file):
-            if files_are_identical(dat_file, backup_file):
-                print("Identical tile {0} of {1}: {2}".format(
-                    startedTiles+1, totTiles, os.path.basename(gz_file)))
-                os.remove(dat_file)
-                os.rename(backup_file, gz_file)
-                return
+    # Check if new file is identical to existing before compressing
+    if os.path.exists(gz_file):
+        if files_are_identical(dat_file, gz_file):
+            print("Identical tile {0} of {1}: {2}".format(
+                startedTiles+1, totTiles, os.path.basename(gz_file)))
+            os.remove(dat_file)
+            return
 
-        # and compress
-        with open(dat_file, 'rb') as f_in:
-            with gzip.open(gz_file, 'wb') as f_out:
-                shutil.copyfileobj(f_in, f_out)
-        os.remove(dat_file)
+    # Compress to temporary file
+    with open(dat_file, 'rb') as f_in:
+        with gzip.open(tmp_gz_file, 'wb') as f_out:
+            shutil.copyfileobj(f_in, f_out)
+    os.remove(dat_file)
 
-        # Remove backup after successful regeneration
-        if backup_file and os.path.exists(backup_file):
-            os.remove(backup_file)
-    except Exception as e:
-        # Always restore backup on any error
-        if backup_file and os.path.exists(backup_file):
-            if not os.path.exists(gz_file):
-                os.rename(backup_file, gz_file)
-                print("Exception occurred, restored backup: {0} ({1})".format(os.path.basename(gz_file), e))
-            else:
-                os.remove(backup_file)
-        raise
+    # Atomic rename to final location (overwrites existing file safely)
+    os.rename(tmp_gz_file, gz_file)
 
     # Log comparison for --regen-ocean mode
     if regen_ocean and old_heights is not None:

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -302,6 +302,8 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
         if files_are_identical(dat_file, gz_file):
             print("Identical tile {0} of {1}: {2}".format(
                 startedTiles+1, totTiles, os.path.basename(gz_file)))
+            if regen_ocean:
+                log_regen(f"{os.path.basename(gz_file)}: identical")
             os.remove(dat_file)
             return
 

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -233,7 +233,7 @@ def log_regen(message):
         regen_log_file.write(message + "\n")
         regen_log_file.flush()
 
-def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, spacing, regen_ocean=False):
+def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, spacing, regen_ocean=False, regen_list=False):
     gz_file = datafile(lat, long, targetFolder) + '.gz'
     dat_file = datafile(lat, long, targetFolder)
     old_heights = None
@@ -256,6 +256,23 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
         elif not os.path.exists(dat_file):
             # No file exists, nothing to regenerate
             return
+    elif regen_list:
+        # Regenerate from list: don't check if affected, just regenerate
+        if os.path.exists(gz_file):
+            print("Regenerating from list tile {0} of {1}: {2}".format(
+                startedTiles+1, totTiles, os.path.basename(gz_file)))
+            # Rename to backup - only delete after successful regeneration
+            backup_file = gz_file + '.bak'
+            os.rename(gz_file, backup_file)
+        elif os.path.exists(dat_file):
+            print("Regenerating from list tile {0} of {1}: {2}".format(
+                startedTiles+1, totTiles, os.path.basename(dat_file)))
+            # Remove uncompressed file to force regeneration
+            os.remove(dat_file)
+        else:
+            # No existing file, just generate fresh
+            print("Generating missing tile {0} of {1}: {2}".format(
+                startedTiles+1, totTiles, os.path.basename(gz_file)))
     else:
         # Normal mode: skip existing compressed tiles
         if os.path.exists(gz_file):
@@ -322,6 +339,50 @@ def datafile(lat, lon, folder):
 
     return name
 
+def parse_tile_name(name):
+    """Parse a tile name like 'N00E006' or 'S45W067' to (lat, lon) tuple.
+
+    Returns (lat, lon) or None if invalid format.
+    """
+    name = name.strip()
+    if len(name) < 7:
+        return None
+
+    try:
+        ns = name[0].upper()
+        lat = int(name[1:3])
+        ew = name[3].upper()
+        lon = int(name[4:7])
+
+        if ns == 'S':
+            lat = -lat
+        elif ns != 'N':
+            return None
+
+        if ew == 'W':
+            lon = -lon
+        elif ew != 'E':
+            return None
+
+        return (lat, lon)
+    except (ValueError, IndexError):
+        return None
+
+def load_regen_list(filepath):
+    """Load list of tile names from file and return as set of (lat, lon) tuples."""
+    tiles = set()
+    with open(filepath, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            result = parse_tile_name(line)
+            if result:
+                tiles.add(result)
+            else:
+                print(f"Warning: Could not parse tile name: {line}")
+    return tiles
+
 def get_size(start_path = '.'):
     total_size = 0
     for dirpath, dirnames, filenames in os.walk(start_path):
@@ -363,6 +424,9 @@ if __name__ == '__main__':
     # Regenerate tiles affected by ocean tile bug
     parser.add_argument('--regen-ocean', action="store_true", dest="regen_ocean",
                         help="Only regenerate tiles affected by the ocean tile bug (coastal tiles with incorrect zero heights)")
+    # Regenerate specific tiles from a list file
+    parser.add_argument('--regen-list', action="store", dest="regen_list",
+                        help="File containing list of tile names to regenerate (e.g., N00E006, one per line)")
     args = parser.parse_args()
 
     targetFolder = os.path.join(os.getcwd(), args.folder)
@@ -395,13 +459,23 @@ if __name__ == '__main__':
 
     downloader = srtm.SRTMDownloader(debug=False, offline=(1 if args.offline else 0), directory=args.database, cachedir=args.cachedir)
     downloader.loadFileList()
-    
+
+    # Load regen list if provided
+    regen_list_tiles = None
+    if args.regen_list:
+        regen_list_tiles = load_regen_list(args.regen_list)
+        print(f"Loaded {len(regen_list_tiles)} tiles from {args.regen_list}")
+
     # make tileID's
     tileID = []
     i = 0
     for long in range(-180, 180):
         for lat in range (-(args.latitude+1), args.latitude+1):
-            tileID.append([lat, long, i]) 
+            # If using --regen-list, only include tiles in the list
+            if regen_list_tiles is not None:
+                if (lat, long) not in regen_list_tiles:
+                    continue
+            tileID.append([lat, long, i])
             i += 1
 
     # total number of tiles
@@ -410,7 +484,7 @@ if __name__ == '__main__':
 
     # Use a pool of workers to process
     with ThreadPool(args.processes-1) as p:
-        reslist = [p.apply_async(worker, args=(downloader, td[0], td[1], targetFolder, td[2], len(tileID), args.format, spacing, args.regen_ocean), error_callback=error_handler) for td in tileID]
+        reslist = [p.apply_async(worker, args=(downloader, td[0], td[1], targetFolder, td[2], len(tileID), args.format, spacing, args.regen_ocean, args.regen_list is not None), error_callback=error_handler) for td in tileID]
         for result in reslist:
             result.get()
 

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -395,6 +395,19 @@ def load_regen_list(filepath):
                 print(f"Warning: Could not parse tile name: {line}")
     return tiles
 
+def scan_existing_tiles(folder):
+    """Scan folder for existing .DAT.gz files and return list of (lat, lon) tuples."""
+    tiles = []
+    for filename in os.listdir(folder):
+        if not filename.endswith('.DAT.gz'):
+            continue
+        # Remove .DAT.gz extension to get tile name
+        tile_name = filename[:-7]
+        result = parse_tile_name(tile_name)
+        if result:
+            tiles.append(result)
+    return sorted(tiles)
+
 def get_size(start_path = '.'):
     total_size = 0
     for dirpath, dirnames, filenames in os.walk(start_path):
@@ -481,14 +494,25 @@ if __name__ == '__main__':
     # make tileID's
     tileID = []
     i = 0
-    for long in range(-180, 180):
-        for lat in range (-(args.latitude+1), args.latitude+1):
-            # If using --regen-list, only include tiles in the list
-            if regen_list_tiles is not None:
-                if (lat, long) not in regen_list_tiles:
-                    continue
+
+    # For --regen-ocean, scan existing files instead of generating grid
+    if args.regen_ocean:
+        existing_tiles = scan_existing_tiles(targetFolder)
+        print(f"Scanning {len(existing_tiles)} existing tiles for ocean bug")
+        for lat, long in existing_tiles:
             tileID.append([lat, long, i])
             i += 1
+    elif regen_list_tiles is not None:
+        # Use tiles from regen list
+        for lat, long in sorted(regen_list_tiles):
+            tileID.append([lat, long, i])
+            i += 1
+    else:
+        # Normal mode: generate grid
+        for long in range(-180, 180):
+            for lat in range(-(args.latitude+1), args.latitude+1):
+                tileID.append([lat, long, i])
+                i += 1
 
     # total number of tiles
     totTiles = len(tileID)

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -12,17 +12,254 @@ import argparse
 import time
 import gzip
 import shutil
+import struct
+import threading
+import math
+from datetime import datetime
 
 import srtm
-from terrain_gen import create_degree
+from terrain_gen import create_degree, add_offset
 
-def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, spacing):
-    # only create if the output file does not exists
-    if os.path.exists(datafile(lat, long, targetFolder) + '.gz'):
-        print("Skipping existing compressed tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+# Thread-safe logging for --regen-ocean
+regen_log_lock = threading.Lock()
+regen_log_file = None
+
+# Date when the ocean tile bug was fixed (used for --regen-ocean)
+# Tiles generated before this date may be affected
+OCEAN_BUG_FIX_DATE = time.mktime(time.strptime("2026-01-12", "%Y-%m-%d"))
+
+def is_tile_affected(filepath):
+    """Check if a DAT.gz file could be affected by the ocean tile bug.
+
+    The bug caused land cells to get zero altitude when processed after ocean tiles.
+    Any tile with both zeros and non-zeros could potentially be affected.
+    Pure ocean (all zeros) and pure land (no zeros) tiles are not affected.
+
+    Returns True if the tile should be regenerated, False to skip.
+    """
+    # Skip files generated after the fix
+    try:
+        if os.path.getmtime(filepath) > OCEAN_BUG_FIX_DATE:
+            return False
+    except OSError:
+        return False
+
+    try:
+        # Read and decompress
+        with gzip.open(filepath, 'rb') as f:
+            data = f.read()
+
+        # Count non-zero heights across all blocks
+        IO_BLOCK_SIZE = 2048
+        total_heights = 0
+        nonzero_count = 0
+        num_blocks = len(data) // IO_BLOCK_SIZE
+
+        for block_idx in range(num_blocks):
+            block_start = block_idx * IO_BLOCK_SIZE
+            # Heights start at offset 22, 896 heights * 2 bytes each
+            height_data = data[block_start + 22:block_start + 22 + 1792]
+            if len(height_data) < 1792:
+                continue
+            heights = struct.unpack('<896h', height_data)
+            total_heights += 896
+            nonzero_count += sum(1 for h in heights if h != 0)
+
+        if total_heights == 0:
+            return False
+
+        # Any tile with both zeros and non-zeros could be affected
+        # Pure ocean (all zeros): not affected - no land to corrupt
+        # Pure land (no zeros): not affected - no ocean tile lookups
+        # Mixed (some zeros, some non-zeros): could be affected
+        has_zeros = nonzero_count < total_heights
+        has_nonzeros = nonzero_count > 0
+        return has_zeros and has_nonzeros
+
+    except Exception as e:
+        print(f"Error checking {filepath}: {e}")
+        return False
+
+def read_tile_heights(filepath):
+    """Read all heights from a DAT or DAT.gz file.
+
+    Returns a list of all height values, or None on error.
+    """
+    try:
+        if filepath.endswith('.gz'):
+            with gzip.open(filepath, 'rb') as f:
+                data = f.read()
+        else:
+            with open(filepath, 'rb') as f:
+                data = f.read()
+
+        IO_BLOCK_SIZE = 2048
+        all_heights = []
+        num_blocks = len(data) // IO_BLOCK_SIZE
+
+        for block_idx in range(num_blocks):
+            block_start = block_idx * IO_BLOCK_SIZE
+            height_data = data[block_start + 22:block_start + 22 + 1792]
+            if len(height_data) < 1792:
+                continue
+            heights = struct.unpack('<896h', height_data)
+            all_heights.extend(heights)
+
+        return all_heights
+    except Exception as e:
+        print(f"Error reading heights from {filepath}: {e}")
+        return None
+
+def compare_tile_heights(old_heights, new_heights):
+    """Compare old and new height data.
+
+    Returns a dict with statistics about the changes.
+    """
+    if old_heights is None or new_heights is None:
+        return None
+    if len(old_heights) != len(new_heights):
+        return None
+
+    GRID_SIZE_X = 32
+    GRID_SIZE_Y = 28
+    HEIGHTS_PER_BLOCK = GRID_SIZE_X * GRID_SIZE_Y
+
+    total_points = len(old_heights)
+    changed_count = 0
+    zeros_to_nonzero = 0  # Bug-affected points (was 0, now has real altitude)
+    max_bug_altitude = 0  # Max altitude among bug-affected points
+    max_bug_altitude_idx = 0
+    # Also track best "isolated" point (surrounded by zeros) for clearer demonstration
+    best_isolated_altitude = 0
+    best_isolated_idx = 0
+
+    for idx, (old_h, new_h) in enumerate(zip(old_heights, new_heights)):
+        if old_h != new_h:
+            changed_count += 1
+            if old_h == 0 and new_h > 0:
+                zeros_to_nonzero += 1
+                # Track the highest altitude that was incorrectly zero
+                if new_h > max_bug_altitude:
+                    max_bug_altitude = new_h
+                    max_bug_altitude_idx = idx
+
+                # Check if this point is "isolated" (neighbors also zero in old data)
+                # This makes for a clearer demonstration since terrain queries interpolate
+                block_num = idx // HEIGHTS_PER_BLOCK
+                pos_in_block = idx % HEIGHTS_PER_BLOCK
+                gx = pos_in_block // GRID_SIZE_Y
+                gy = pos_in_block % GRID_SIZE_Y
+
+                if 1 <= gx < 31 and 1 <= gy < 27:  # Not on edge
+                    block_base = block_num * HEIGHTS_PER_BLOCK
+                    neighbors_zero = True
+                    for dx, dy in [(-1,0), (1,0), (0,-1), (0,1)]:
+                        nidx = block_base + (gx+dx) * GRID_SIZE_Y + (gy+dy)
+                        if nidx < len(old_heights) and old_heights[nidx] != 0:
+                            neighbors_zero = False
+                            break
+                    if neighbors_zero and new_h > best_isolated_altitude:
+                        best_isolated_altitude = new_h
+                        best_isolated_idx = idx
+
+    # Prefer isolated point for location if available, otherwise use max
+    if best_isolated_altitude > 0:
+        report_altitude = best_isolated_altitude
+        report_idx = best_isolated_idx
+    else:
+        report_altitude = max_bug_altitude
+        report_idx = max_bug_altitude_idx
+
+    return {
+        'total_points': total_points,
+        'changed_count': changed_count,
+        'changed_pct': (changed_count / total_points * 100) if total_points > 0 else 0,
+        'zeros_to_nonzero': zeros_to_nonzero,
+        'zeros_to_nonzero_pct': (zeros_to_nonzero / total_points * 100) if total_points > 0 else 0,
+        'max_bug_altitude': max_bug_altitude,
+        'report_altitude': report_altitude,
+        'report_idx': report_idx
+    }
+
+def index_to_latlon(filepath, idx, spacing):
+    """Convert a height index to lat/lon coordinates.
+
+    Each block has 896 heights (32x28 grid). The block header contains
+    the lat/lon of the block's SW corner in 1e7 format.
+    """
+    try:
+        if filepath.endswith('.gz'):
+            with gzip.open(filepath, 'rb') as f:
+                data = f.read()
+        else:
+            with open(filepath, 'rb') as f:
+                data = f.read()
+
+        IO_BLOCK_SIZE = 2048
+        GRID_SIZE_X = 32
+        GRID_SIZE_Y = 28
+        HEIGHTS_PER_BLOCK = GRID_SIZE_X * GRID_SIZE_Y  # 896
+
+        block_num = idx // HEIGHTS_PER_BLOCK
+        pos_in_block = idx % HEIGHTS_PER_BLOCK
+
+        # Heights are stored column-major: gx varies slower
+        gx = pos_in_block // GRID_SIZE_Y
+        gy = pos_in_block % GRID_SIZE_Y
+
+        # Read block header to get base lat/lon
+        block_start = block_num * IO_BLOCK_SIZE
+        if block_start + 22 > len(data):
+            return None, None
+
+        # Header: bitmap(8) + lat(4) + lon(4) + ...
+        header = data[block_start:block_start + 16]
+        (bitmap, lat_e7, lon_e7) = struct.unpack("<Qii", header)
+
+        # Use the same offset calculation as terrain_gen.py
+        lat_e7_out, lon_e7_out = add_offset(lat_e7, lon_e7, gx * spacing, gy * spacing, "4.1")
+
+        return lat_e7_out * 1e-7, lon_e7_out * 1e-7
+    except Exception as e:
+        print(f"Error converting index to lat/lon: {e}")
+        return None, None
+
+def log_regen(message):
+    """Thread-safe logging to regen-ocean.log"""
+    global regen_log_file
+    if regen_log_file is None:
         return
+    with regen_log_lock:
+        regen_log_file.write(message + "\n")
+        regen_log_file.flush()
 
-    if not os.path.exists(datafile(lat, long, targetFolder)):
+def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, spacing, regen_ocean=False):
+    gz_file = datafile(lat, long, targetFolder) + '.gz'
+    dat_file = datafile(lat, long, targetFolder)
+    old_heights = None
+
+    # Check if we need to regenerate due to ocean tile bug
+    if regen_ocean:
+        if os.path.exists(gz_file):
+            if is_tile_affected(gz_file):
+                print("Regenerating ocean-bug-affected tile {0} of {1}: {2}".format(
+                    startedTiles+1, totTiles, os.path.basename(gz_file)))
+                # Read old heights before removing for comparison
+                old_heights = read_tile_heights(gz_file)
+                os.remove(gz_file)
+            else:
+                # Tile is not affected, skip it
+                return
+        elif not os.path.exists(dat_file):
+            # No file exists, nothing to regenerate
+            return
+    else:
+        # Normal mode: skip existing compressed tiles
+        if os.path.exists(gz_file):
+            print("Skipping existing compressed tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+            return
+
+    if not os.path.exists(dat_file):
         if not create_degree(downloader, lat, long, targetFolder, spacing, format):
             #print("Skipping not downloaded tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
             time.sleep(0.2)
@@ -32,10 +269,30 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
         print("Skipping existing tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
 
     # and compress
-    with open(datafile(lat, long, targetFolder), 'rb') as f_in:
-        with gzip.open(datafile(lat, long, targetFolder) + '.gz', 'wb') as f_out:
+    with open(dat_file, 'rb') as f_in:
+        with gzip.open(gz_file, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
-    os.remove(datafile(lat, long, targetFolder))
+    os.remove(dat_file)
+
+    # Log comparison for --regen-ocean mode
+    if regen_ocean and old_heights is not None:
+        new_heights = read_tile_heights(gz_file)
+        stats = compare_tile_heights(old_heights, new_heights)
+        if stats and stats['zeros_to_nonzero'] > 0:
+            tile_name = os.path.basename(gz_file)
+            rep_lat, rep_lon = index_to_latlon(gz_file, stats['report_idx'], spacing)
+            if rep_lat is not None:
+                loc_str = f", example: {stats['report_altitude']}m at {rep_lat:.6f},{rep_lon:.6f}"
+            else:
+                loc_str = ""
+            log_regen(f"{tile_name}: {stats['zeros_to_nonzero_pct']:.2f}% bug-affected ({stats['zeros_to_nonzero']}/{stats['total_points']} points), "
+                      f"max corrected altitude {stats['max_bug_altitude']}m{loc_str}")
+        elif stats and stats['changed_count'] > 0:
+            tile_name = os.path.basename(gz_file)
+            log_regen(f"{tile_name}: {stats['changed_count']} points changed but none were zero->nonzero")
+        elif stats:
+            tile_name = os.path.basename(gz_file)
+            log_regen(f"{tile_name}: no changes (tile was not actually affected)")
 
     print("Done tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles+1)/totTiles)*100))
     print("Folder is {0:.0f}Mb in size".format(get_size(targetFolder)/(1024*1024)))
@@ -74,7 +331,6 @@ def error_handler(e):
     print('Worker exception: {0}'.format(e))
     
 if __name__ == '__main__':
-    global filelistDownloadActive
     # Create the parser
     parser = argparse.ArgumentParser(description='ArduPilot Terrain DAT file generator')
 
@@ -93,6 +349,9 @@ if __name__ == '__main__':
     parser.add_argument("--database", type=str, default="SRTM1", choices=["SRTM1", "SRTM3"])
     # Cache dir
     parser.add_argument('--cachedir', action="store", default=None)
+    # Regenerate tiles affected by ocean tile bug
+    parser.add_argument('--regen-ocean', action="store_true", dest="regen_ocean",
+                        help="Only regenerate tiles affected by the ocean tile bug (coastal tiles with incorrect zero heights)")
     args = parser.parse_args()
 
     targetFolder = os.path.join(os.getcwd(), args.folder)
@@ -103,6 +362,16 @@ if __name__ == '__main__':
         pass
 
     print("Storing in " + targetFolder)
+
+    # Open log file for --regen-ocean mode
+    if args.regen_ocean:
+        regen_log_file = open("regen-ocean.log", "a")
+        regen_log_file.write(f"\n{'='*60}\n")
+        regen_log_file.write(f"Regeneration started: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        regen_log_file.write(f"Target folder: {targetFolder}\n")
+        regen_log_file.write(f"Database: {args.database}\n")
+        regen_log_file.write(f"{'='*60}\n")
+        regen_log_file.flush()
 
     # store the threads
     processes = []
@@ -130,9 +399,15 @@ if __name__ == '__main__':
 
     # Use a pool of workers to process
     with ThreadPool(args.processes-1) as p:
-        reslist = [p.apply_async(worker, args=(downloader, td[0], td[1], targetFolder, td[2], len(tileID), args.format, spacing), error_callback=error_handler) for td in tileID]
+        reslist = [p.apply_async(worker, args=(downloader, td[0], td[1], targetFolder, td[2], len(tileID), args.format, spacing, args.regen_ocean), error_callback=error_handler) for td in tileID]
         for result in reslist:
             result.get()
+
+    # Close log file for --regen-ocean mode
+    if args.regen_ocean and regen_log_file:
+        regen_log_file.write(f"Regeneration completed: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+        regen_log_file.close()
+        print("Regeneration log written to regen-ocean.log")
 
     print("--------------------------")
     print("All tiles generated!")

--- a/offline_gen.py
+++ b/offline_gen.py
@@ -237,6 +237,7 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
     gz_file = datafile(lat, long, targetFolder) + '.gz'
     dat_file = datafile(lat, long, targetFolder)
     old_heights = None
+    backup_file = None
 
     # Check if we need to regenerate due to ocean tile bug
     if regen_ocean:
@@ -244,9 +245,11 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
             if is_tile_affected(gz_file):
                 print("Regenerating ocean-bug-affected tile {0} of {1}: {2}".format(
                     startedTiles+1, totTiles, os.path.basename(gz_file)))
-                # Read old heights before removing for comparison
+                # Read old heights for comparison (don't delete yet!)
                 old_heights = read_tile_heights(gz_file)
-                os.remove(gz_file)
+                # Rename to backup - only delete after successful regeneration
+                backup_file = gz_file + '.bak'
+                os.rename(gz_file, backup_file)
             else:
                 # Tile is not affected, skip it
                 return
@@ -262,6 +265,10 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
     if not os.path.exists(dat_file):
         if not create_degree(downloader, lat, long, targetFolder, spacing, format):
             #print("Skipping not downloaded tile {0} of {1} ({2:.3f}%)".format(startedTiles+1, totTiles, ((startedTiles)/totTiles)*100))
+            # Restore backup if regeneration failed
+            if backup_file and os.path.exists(backup_file):
+                os.rename(backup_file, gz_file)
+                print("Regeneration failed, restored backup: {0}".format(os.path.basename(gz_file)))
             time.sleep(0.2)
             return
         print("Created tile {0} of {1}".format(startedTiles, totTiles))
@@ -273,6 +280,10 @@ def worker(downloader, lat, long, targetFolder, startedTiles, totTiles, format, 
         with gzip.open(gz_file, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
     os.remove(dat_file)
+
+    # Remove backup after successful regeneration
+    if backup_file and os.path.exists(backup_file):
+        os.remove(backup_file)
 
     # Log comparison for --regen-ocean mode
     if regen_ocean and old_heights is not None:

--- a/resample_hgt.py
+++ b/resample_hgt.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+'''Resample SRTM1 (3601x3601) HGT zip files to SRTM3 (1201x1201).
+Takes every 3rd pixel in both axes.'''
+
+import argparse
+import glob
+import math
+import os
+import struct
+import sys
+import zipfile
+from multiprocessing import Pool
+
+
+def resample_file(args):
+    '''Resample one HGT file from SRTM1 to SRTM3.'''
+    inpath, outpath, overwrite = args
+    basename = os.path.basename(inpath)
+    try:
+        if os.path.exists(outpath) and not overwrite:
+            return (basename, "skipped")
+
+        with zipfile.ZipFile(inpath, 'r') as zf:
+            inner_name = zf.namelist()[0]
+            data = zf.read(inner_name)
+
+        size = int(math.sqrt(len(data) // 2))
+        if size != 3601:
+            return (basename, "not SRTM1 (size=%d)" % size)
+
+        # Parse as big-endian int16 rows, take every 3rd pixel
+        row_bytes = size * 2
+        out_rows = []
+        for row in range(0, size, 3):
+            offset = row * row_bytes
+            row_data = struct.unpack('>%dh' % size, data[offset:offset + row_bytes])
+            out_rows.append(struct.pack('>%dh' % 1201, *row_data[::3]))
+
+        out_data = b''.join(out_rows)
+
+        # Write as zip with same inner name
+        os.makedirs(os.path.dirname(outpath), exist_ok=True)
+        tmp_path = outpath + '.tmp'
+        with zipfile.ZipFile(tmp_path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(inner_name, out_data)
+        os.rename(tmp_path, outpath)
+
+        return (basename, "ok")
+    except Exception as e:
+        return (basename, "error: %s" % e)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Resample SRTM1 HGT files to SRTM3')
+    parser.add_argument('input_dir', help='Directory containing SRTM1 .hgt.zip files')
+    parser.add_argument('output_dir', help='Output directory for SRTM3 .hgt.zip files')
+    parser.add_argument('--processes', type=int, default=8, help='Number of parallel workers')
+    parser.add_argument('--overwrite', action='store_true', help='Overwrite existing files')
+    args = parser.parse_args()
+
+    files = sorted(glob.glob(os.path.join(args.input_dir, '**/*.hgt.zip'), recursive=True))
+    if not files:
+        print("No .hgt.zip files found in %s" % args.input_dir)
+        sys.exit(1)
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    work = []
+    for f in files:
+        basename = os.path.basename(f)
+        outpath = os.path.join(args.output_dir, basename)
+        work.append((f, outpath, args.overwrite))
+
+    print("Resampling %d files with %d processes..." % (len(work), args.processes))
+
+    errors = 0
+    done = 0
+    skipped = 0
+    with Pool(processes=args.processes) as pool:
+        for basename, status in pool.imap_unordered(resample_file, work, chunksize=16):
+            if status == "ok":
+                done += 1
+            elif status == "skipped":
+                skipped += 1
+            else:
+                errors += 1
+                print("  %s: %s" % (basename, status))
+            if (done + skipped + errors) % 1000 == 0:
+                print("  %d / %d processed" % (done + skipped + errors, len(work)))
+
+    print("Done: %d resampled, %d skipped, %d errors" % (done, skipped, errors))
+
+
+if __name__ == '__main__':
+    main()

--- a/slice_graph.py
+++ b/slice_graph.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+'''
+Horizontal altitude slice visualiser for comparing DAT and HGT terrain data.
+Shows altitude profiles at a given latitude across a terrain tile, useful for
+spotting horizontal offsets between ground truth (HGT) and generated (DAT) data.
+'''
+
+import argparse
+import array
+import gzip
+import math
+import os
+import re
+import struct
+import zipfile
+
+import matplotlib.pyplot as plt
+
+# Constants from terrain_gen.py
+TERRAIN_GRID_MAVLINK_SIZE = 4
+TERRAIN_GRID_BLOCK_MUL_X = 7
+TERRAIN_GRID_BLOCK_MUL_Y = 8
+TERRAIN_GRID_BLOCK_SPACING_X = (TERRAIN_GRID_BLOCK_MUL_X - 1) * TERRAIN_GRID_MAVLINK_SIZE  # 24
+TERRAIN_GRID_BLOCK_SPACING_Y = (TERRAIN_GRID_BLOCK_MUL_Y - 1) * TERRAIN_GRID_MAVLINK_SIZE  # 28
+TERRAIN_GRID_BLOCK_SIZE_X = TERRAIN_GRID_MAVLINK_SIZE * TERRAIN_GRID_BLOCK_MUL_X   # 28
+TERRAIN_GRID_BLOCK_SIZE_Y = TERRAIN_GRID_MAVLINK_SIZE * TERRAIN_GRID_BLOCK_MUL_Y   # 32
+IO_BLOCK_SIZE = 2048
+
+
+def to_float32(f):
+    '''Emulate single precision float'''
+    return struct.unpack('f', struct.pack('f', f))[0]
+
+
+LOCATION_SCALING_FACTOR = to_float32(0.011131884502145034)
+LOCATION_SCALING_FACTOR_INV = to_float32(89.83204953368922)
+
+
+def longitude_scale(lat):
+    '''Get longitude scale factor'''
+    scale = to_float32(math.cos(to_float32(math.radians(lat))))
+    return max(scale, 0.01)
+
+
+def diff_longitude_E7(lon1, lon2):
+    '''Get longitude difference, handling wrap'''
+    if lon1 * lon2 >= 0:
+        return lon1 - lon2
+    dlon = lon1 - lon2
+    if dlon > 1800000000:
+        dlon -= 3600000000
+    elif dlon < -1800000000:
+        dlon += 3600000000
+    return dlon
+
+
+def get_distance_NE_e7(lat1, lon1, lat2, lon2, fmt="4.1"):
+    '''Get distance tuple between two positions in 1e7 format'''
+    if fmt == "pre-4.1":
+        return ((lat2 - lat1) * LOCATION_SCALING_FACTOR,
+                (lon2 - lon1) * LOCATION_SCALING_FACTOR * longitude_scale(lat1 * 1.0e-7))
+    dlat = lat2 - lat1
+    dlng = diff_longitude_E7(lon2, lon1) * longitude_scale((lat1 + lat2) * 0.5 * 1.0e-7)
+    return (dlat * LOCATION_SCALING_FACTOR, dlng * LOCATION_SCALING_FACTOR)
+
+
+def parse_tile_name(filename):
+    '''Extract lat/lon from filename like N83W033.DAT.gz or N83W033.hgt.zip'''
+    basename = os.path.basename(filename)
+    match = re.match(r'([NS])(\d{2})([EW])(\d{3})', basename)
+    if not match:
+        raise ValueError("Cannot parse tile name from %s" % filename)
+    lat = int(match.group(2))
+    lon = int(match.group(4))
+    if match.group(1) == 'S':
+        lat = -lat
+    if match.group(3) == 'W':
+        lon = -lon
+    return lat, lon
+
+
+def read_dat_blocks(filepath):
+    '''Read all blocks from a DAT or DAT.gz file.
+    Returns (blocks_dict, tile_lat, tile_lon, spacing) where
+    blocks_dict maps (grid_idx_x, grid_idx_y) to height[BLOCK_SIZE_X][BLOCK_SIZE_Y]
+    '''
+    if filepath.endswith('.gz'):
+        with gzip.open(filepath, 'rb') as f:
+            data = f.read()
+    else:
+        with open(filepath, 'rb') as f:
+            data = f.read()
+
+    blocks = {}
+    tile_lat = None
+    tile_lon = None
+    spacing = None
+
+    num_blocks = len(data) // IO_BLOCK_SIZE
+    for i in range(num_blocks):
+        block_data = data[i * IO_BLOCK_SIZE:(i + 1) * IO_BLOCK_SIZE]
+        if len(block_data) < IO_BLOCK_SIZE:
+            break
+
+        # Parse header: bitmap(Q) lat(i) lon(i) crc(H) version(H) spacing(H)
+        bitmap, lat, lon, crc, version, sp = struct.unpack("<QiiHHH", block_data[:22])
+        if version == 0 and sp == 0:
+            continue  # empty block
+
+        # Parse heights: BLOCK_SIZE_X rows of BLOCK_SIZE_Y int16
+        heights = []
+        offset = 22
+        for gx in range(TERRAIN_GRID_BLOCK_SIZE_X):
+            row = struct.unpack("<%dh" % TERRAIN_GRID_BLOCK_SIZE_Y,
+                                block_data[offset:offset + TERRAIN_GRID_BLOCK_SIZE_Y * 2])
+            heights.append(list(row))
+            offset += TERRAIN_GRID_BLOCK_SIZE_Y * 2
+
+        # Parse trailer: grid_idx_x(H) grid_idx_y(H) lon_degrees(h) lat_degrees(b)
+        grid_idx_x, grid_idx_y, lon_deg, lat_deg = struct.unpack("<HHhb", block_data[offset:offset + 7])
+
+        if tile_lat is None:
+            tile_lat = lat_deg
+            tile_lon = lon_deg
+            spacing = sp
+
+        blocks[(grid_idx_x, grid_idx_y)] = heights
+
+    return blocks, tile_lat, tile_lon, spacing
+
+
+def read_hgt_data(filepath):
+    '''Read HGT data from .hgt.zip file.
+    Returns (data_array, size) where size is 1201 or 3601.
+    '''
+    with zipfile.ZipFile(filepath, 'r') as zf:
+        names = zf.namelist()
+        raw = zf.read(names[0])
+
+    size = int(math.sqrt(len(raw) / 2))
+    data = array.array('h', raw)
+    data.byteswap()
+    return data, size
+
+
+def dat_altitude(lat, lon, blocks, tile_lat, tile_lon, spacing, fmt="4.1"):
+    '''Compute altitude from DAT data using AP_Terrain interpolation.
+    Single-step get_distance_NE from degree corner, matching vehicle code.
+    '''
+    ref_lat = int(tile_lat * 1e7)
+    ref_lon = int(tile_lon * 1e7)
+    point_lat = int(lat * 1e7)
+    point_lon = int(lon * 1e7)
+
+    offset = get_distance_NE_e7(ref_lat, ref_lon, point_lat, point_lon, fmt)
+    offset_north = offset[0]
+    offset_east = offset[1]
+
+    idx_x = int(offset_north / spacing)
+    idx_y = int(offset_east / spacing)
+
+    grid_idx_x = idx_x // TERRAIN_GRID_BLOCK_SPACING_X
+    grid_idx_y = idx_y // TERRAIN_GRID_BLOCK_SPACING_Y
+
+    local_x = idx_x % TERRAIN_GRID_BLOCK_SPACING_X
+    local_y = idx_y % TERRAIN_GRID_BLOCK_SPACING_Y
+
+    frac_x = (offset_north - idx_x * spacing) / spacing
+    frac_y = (offset_east - idx_y * spacing) / spacing
+
+    key = (grid_idx_x, grid_idx_y)
+    if key not in blocks:
+        return None
+
+    heights = blocks[key]
+
+    if local_x < 0 or local_x + 1 >= TERRAIN_GRID_BLOCK_SIZE_X:
+        return None
+    if local_y < 0 or local_y + 1 >= TERRAIN_GRID_BLOCK_SIZE_Y:
+        return None
+
+    h00 = heights[local_x][local_y]
+    h01 = heights[local_x][local_y + 1]
+    h10 = heights[local_x + 1][local_y]
+    h11 = heights[local_x + 1][local_y + 1]
+
+    avg1 = (1 - frac_x) * h00 + frac_x * h10
+    avg2 = (1 - frac_x) * h01 + frac_x * h11
+    result = (1 - frac_y) * avg1 + frac_y * avg2
+
+    return result
+
+
+def hgt_altitude(lat, lon, hgt_data, tile_lat, tile_lon, hgt_size):
+    '''Compute altitude from HGT data using srtm.py interpolation.'''
+    lat_norm = lat - tile_lat
+    lon_norm = lon - tile_lon
+
+    if lat_norm < 0 or lat_norm >= 1 or lon_norm < 0 or lon_norm >= 1:
+        return None
+
+    x = lon_norm * (hgt_size - 1)
+    y = lat_norm * (hgt_size - 1)
+
+    x_int = int(x)
+    x_frac = x - x_int
+    y_int = int(y)
+    y_frac = y - y_int
+
+    def get_pixel(px, py):
+        if px >= hgt_size or py >= hgt_size:
+            return None
+        offset = px + hgt_size * (hgt_size - py - 1)
+        value = hgt_data[offset]
+        if value == -32768:
+            return -1
+        return value
+
+    def avg(v1, v2, w):
+        if v1 is None:
+            return v2
+        if v2 is None:
+            return v1
+        return v2 * w + v1 * (1 - w)
+
+    v00 = get_pixel(x_int, y_int)
+    v10 = get_pixel(x_int + 1, y_int)
+    v01 = get_pixel(x_int, y_int + 1)
+    v11 = get_pixel(x_int + 1, y_int + 1)
+
+    v1 = avg(v00, v10, x_frac)
+    v2 = avg(v01, v11, x_frac)
+    result = avg(v1, v2, y_frac)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Horizontal altitude slice visualiser for DAT and HGT terrain data')
+    parser.add_argument('files', nargs='+', help='.DAT.gz and/or .hgt.zip files for the same tile')
+    parser.add_argument('--percent', type=float, default=50,
+                        help='Latitude as percentage through tile (0=south, 100=north)')
+    parser.add_argument('--step', type=float, default=10,
+                        help='Horizontal sample step in metres')
+    parser.add_argument('--format', type=str, default='4.1', choices=['4.1', 'pre-4.1'],
+                        help='ArduPilot coordinate format version')
+    parser.add_argument('-o', type=str, default=None,
+                        help='Save plot to file instead of showing interactively')
+    args = parser.parse_args()
+
+    # Determine tile lat/lon from first file
+    tile_lat, tile_lon = parse_tile_name(args.files[0])
+
+    # Compute target latitude from percentage
+    target_lat = tile_lat + args.percent / 100.0
+
+    # Generate longitude sample points
+    lon_step_deg = args.step / (111320.0 * math.cos(math.radians(target_lat)))
+    lons = []
+    lon = float(tile_lon)
+    while lon < tile_lon + 1.0:
+        lons.append(lon)
+        lon += lon_step_deg
+
+    print("Tile: %d,%d  Target lat: %.6f  Samples: %d" % (tile_lat, tile_lon, target_lat, len(lons)))
+
+    fig, ax = plt.subplots(figsize=(14, 6))
+
+    for filepath in args.files:
+        label = os.path.basename(filepath)
+        alts = []
+
+        if '.DAT' in filepath:
+            blocks, t_lat, t_lon, spacing = read_dat_blocks(filepath)
+            print("  %s: %d blocks, spacing=%dm" % (label, len(blocks), spacing))
+            for lon_val in lons:
+                alt = dat_altitude(target_lat, lon_val, blocks, t_lat, t_lon, spacing, args.format)
+                alts.append(alt)
+        elif '.hgt' in filepath.lower():
+            file_lat, file_lon = parse_tile_name(filepath)
+            hgt_data, hgt_size = read_hgt_data(filepath)
+            print("  %s: %dx%d pixels" % (label, hgt_size, hgt_size))
+            for lon_val in lons:
+                alt = hgt_altitude(target_lat, lon_val, hgt_data, file_lat, file_lon, hgt_size)
+                alts.append(alt)
+        else:
+            print("  Skipping unrecognised file: %s" % filepath)
+            continue
+
+        # Filter out None values for plotting
+        plot_lons = [lons[i] for i in range(len(alts)) if alts[i] is not None]
+        plot_alts = [a for a in alts if a is not None]
+        ax.plot(plot_lons, plot_alts, label=label, linewidth=0.8)
+
+    ax.set_xlabel('Longitude')
+    ax.set_ylabel('Altitude (m)')
+    ax.set_title('Altitude slice at lat=%.4f (%g%% through tile)' % (target_lat, args.percent))
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    if args.o:
+        fig.savefig(args.o, dpi=150, bbox_inches='tight')
+        print("Saved to %s" % args.o)
+    else:
+        plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/srtm.py
+++ b/srtm.py
@@ -184,6 +184,9 @@ class SRTMDownloader():
             data = self.getURIWithRedirect(self.directory)
         except Exception:
             return
+        # Ensure data is a string for HTMLParser
+        if isinstance(data, bytes):
+            data = data.decode('utf-8')
         parser = parseHTMLDirectoryListing()
         parser.feed(data)
         continents = parser.getDirListing()
@@ -214,6 +217,9 @@ class SRTMDownloader():
                 except Exception as ex:
                     print("Failed to download %s : %s" % (url, ex))
                     continue
+                # Ensure data is a string for HTMLParser
+                if isinstance(data, bytes):
+                    data = data.decode('utf-8')
                 parser = parseHTMLDirectoryListing()
                 parser.feed(data)
                 files = parser.getDirListing()
@@ -268,7 +274,8 @@ class SRTMDownloader():
                 print("still getting file list")
             return 0
         elif not os.path.isfile(self.filelist_file) and filelistDownloadActive == 0:
-            self.createFileList()
+            if self.offline == 0:
+                self.createFileList()
             return 0
         elif not self.filelist:
             if self.debug:

--- a/terrain_gen.py
+++ b/terrain_gen.py
@@ -293,7 +293,10 @@ def create_degree(downloader, lat, lon, folder, grid_spacing, format):
             continue
         for gx in range(TERRAIN_GRID_BLOCK_SIZE_X):
             for gy in range(TERRAIN_GRID_BLOCK_SIZE_Y):
-                lat_e7, lon_e7 = add_offset(lat*1.0e7, lon*1.0e7, gx*grid_spacing, gy*grid_spacing, format)
+                lat_e7, lon_e7 = add_offset(lat_int*1e7, lon_int*1e7,
+                                            (grid.grid_idx_x * TERRAIN_GRID_BLOCK_SPACING_X + gx) * grid_spacing,
+                                            (grid.grid_idx_y * TERRAIN_GRID_BLOCK_SPACING_Y + gy) * grid_spacing,
+                                            format)
                 lat2_int = int(math.floor(lat_e7*1.0e-7))
                 lon2_int = int(math.floor(lon_e7*1.0e-7))
                 tile_idx = (lat2_int, lon2_int)

--- a/terrain_gen.py
+++ b/terrain_gen.py
@@ -300,8 +300,8 @@ def create_degree(downloader, lat, lon, folder, grid_spacing, format):
                 while not tile_idx in tiles:
                     tile = downloader.getTile(lat2_int, lon2_int)
                     waited = False
-                    if (tile == 0 and downloader.offline == 1) or (isinstance(tile, srtm.SRTMOceanTile) and downloader.offline == 1):
-                        #skip tile
+                    if tile == 0 and downloader.offline == 1:
+                        # In offline mode, can't wait for download - skip this tile
                         dfile.remove()
                         return False
                     elif tile == 0:

--- a/terrain_view.py
+++ b/terrain_view.py
@@ -163,10 +163,10 @@ def blocks_to_grid(blocks):
     return height_grid
 
 
-def height_to_rgb(height_grid):
+def height_to_rgb(height_grid, grey=False):
     """Convert height grid to RGB image.
 
-    0 = black. Non-zero heights mapped blue (lowest) to red (highest).
+    0 = black. Non-zero heights mapped blue-to-red (default) or greyscale.
     """
     rgb = np.zeros((*height_grid.shape, 3), dtype=np.uint8)
 
@@ -178,17 +178,22 @@ def height_to_rgb(height_grid):
     nz_max = height_grid[nonzero].max()
 
     if nz_max == nz_min:
-        # All non-zero values the same - use mid colour
-        rgb[nonzero] = [128, 0, 128]
+        rgb[nonzero] = [128, 128, 128] if grey else [128, 0, 128]
         return rgb
 
     # Normalise non-zero heights to 0..1
     t = (height_grid[nonzero].astype(np.float32) - nz_min) / (nz_max - nz_min)
 
-    # Blue (0,0,255) at t=0 to Red (255,0,0) at t=1
-    rgb[nonzero, 0] = (t * 255).astype(np.uint8)         # R
-    rgb[nonzero, 1] = 0                                   # G
-    rgb[nonzero, 2] = ((1 - t) * 255).astype(np.uint8)   # B
+    if grey:
+        v = (t * 255).astype(np.uint8)
+        rgb[nonzero, 0] = v
+        rgb[nonzero, 1] = v
+        rgb[nonzero, 2] = v
+    else:
+        # Blue (0,0,255) at t=0 to Red (255,0,0) at t=1
+        rgb[nonzero, 0] = (t * 255).astype(np.uint8)         # R
+        rgb[nonzero, 1] = 0                                   # G
+        rgb[nonzero, 2] = ((1 - t) * 255).astype(np.uint8)   # B
 
     return rgb
 
@@ -239,13 +244,13 @@ def grid_to_latlon(grid_x, grid_y, tile_lat, tile_lon, spacing):
     return lat, lon
 
 
-def show_file(datfile, plt):
+def show_file(datfile, plt, grey=False):
     """Open a viewer window for one DAT file."""
     height_grid, tile_lat, tile_lon, spacing = load_file(datfile)
     if height_grid is None:
         return
 
-    rgb = height_to_rgb(height_grid)
+    rgb = height_to_rgb(height_grid, grey=grey)
 
     # Flip so north is up (row 0 = bottom of grid = south)
     rgb = rgb[::-1, :, :]
@@ -325,7 +330,7 @@ def resample_grid(grid, old_spacing, new_spacing):
     return grid[row_idx][:, col_idx]
 
 
-def show_diff(file1, file2, plt):
+def show_diff(file1, file2, plt, grey=False):
     """Show two files and their difference."""
     grid1, tile_lat1, tile_lon1, spacing1 = load_file(file1)
     grid2, tile_lat2, tile_lon2, spacing2 = load_file(file2)
@@ -365,8 +370,8 @@ def show_diff(file1, file2, plt):
     n_diff = np.count_nonzero(diff)
     print(f"  Diff: {n_diff} pixels differ, range {diff.min()} to {diff.max()}")
 
-    rgb1 = height_to_rgb(grid1)[::-1, :, :]
-    rgb2 = height_to_rgb(grid2)[::-1, :, :]
+    rgb1 = height_to_rgb(grid1, grey=grey)[::-1, :, :]
+    rgb2 = height_to_rgb(grid2, grey=grey)[::-1, :, :]
     rgb_diff = diff_to_rgb(diff)[::-1, :, :]
     h1 = grid1[::-1, :]
     h2 = grid2[::-1, :]
@@ -416,6 +421,8 @@ def main():
     parser.add_argument('datfiles', nargs='+', help='Path to .DAT, .DAT.gz, .hgt, or .hgt.zip files')
     parser.add_argument('--diff', action='store_true',
                         help='Show difference between exactly 2 files')
+    parser.add_argument('--grey', action='store_true',
+                        help='Show heights as greyscale instead of blue-to-red')
     args = parser.parse_args()
 
     if args.diff:
@@ -426,10 +433,10 @@ def main():
     import matplotlib.pyplot as plt
 
     if args.diff:
-        show_diff(args.datfiles[0], args.datfiles[1], plt)
+        show_diff(args.datfiles[0], args.datfiles[1], plt, grey=args.grey)
     else:
         for datfile in args.datfiles:
-            show_file(datfile, plt)
+            show_file(datfile, plt, grey=args.grey)
 
     plt.show()
 

--- a/terrain_view.py
+++ b/terrain_view.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""
+Visualise ArduPilot terrain .DAT files or SRTM .hgt files as 2D images.
+
+Height 0 is black. Non-zero heights are coloured blue (lowest) to red (highest).
+Mouse cursor position shows the lat/lon and height.
+
+Usage:
+    python3 terrain_view.py <file.DAT or file.DAT.gz or file.hgt.zip>
+    python3 terrain_view.py --diff <file1> <file2>
+"""
+
+import argparse
+import gzip
+import math
+import os
+import re
+import struct
+import sys
+import zipfile
+import numpy as np
+
+IO_BLOCK_SIZE = 2048
+GRID_SIZE_X = 28   # latitude (north), 7 * 4
+GRID_SIZE_Y = 32   # longitude (east), 8 * 4
+BLOCK_SPACING_X = 24  # (7-1) * 4, blocks overlap by 4
+BLOCK_SPACING_Y = 28  # (8-1) * 4, blocks overlap by 4
+
+# HGT filename pattern
+HGT_FILENAME_RE = re.compile(r'([NS])(\d{2})([EW])(\d{3})\.hgt(?:\.zip)?$', re.IGNORECASE)
+
+
+def parse_hgt_filename(filepath):
+    """Parse lat/lon from an HGT filename. Returns (lat, lon) or None."""
+    basename = os.path.basename(filepath)
+    m = HGT_FILENAME_RE.match(basename)
+    if m is None:
+        return None
+    lat = int(m.group(2))
+    lon = int(m.group(4))
+    if m.group(1).upper() == 'S':
+        lat = -lat
+    if m.group(3).upper() == 'W':
+        lon = -lon
+    return (lat, lon)
+
+
+def read_hgt_file(filepath):
+    """Read an HGT or HGT.zip file and return (height_grid, tile_lat, tile_lon, spacing).
+
+    Returns grid with row 0 = south (same orientation as DAT files).
+    """
+    coords = parse_hgt_filename(filepath)
+    if coords is None:
+        raise ValueError(f"Cannot parse lat/lon from filename: {filepath}")
+
+    tile_lat, tile_lon = coords
+
+    if filepath.lower().endswith('.zip'):
+        with zipfile.ZipFile(filepath, 'r') as zf:
+            names = zf.namelist()
+            if len(names) != 1:
+                raise ValueError(f"Expected 1 file in zip, got {len(names)}: {filepath}")
+            data = zf.read(names[0])
+    else:
+        with open(filepath, 'rb') as f:
+            data = f.read()
+
+    size = int(math.sqrt(len(data) // 2))
+    if size not in (1201, 3601):
+        raise ValueError(f"Unexpected HGT size {size} in {filepath}")
+
+    # HGT files are big-endian int16, row 0 = north
+    arr = np.frombuffer(data, dtype='>i2').reshape(size, size).astype(np.int16)
+    # Flip so row 0 = south (consistent with DAT grid orientation)
+    arr = arr[::-1].copy()
+
+    # Spacing: SRTM3 (1201) = ~90m, SRTM1 (3601) = ~30m
+    # More precisely: 1 degree / (size-1) pixels, converted to metres at equator
+    spacing = int(round(111320.0 / (size - 1)))
+
+    return arr, tile_lat, tile_lon, spacing
+
+
+def is_hgt_file(filepath):
+    """Check if filepath is an HGT file."""
+    lower = filepath.lower()
+    return lower.endswith('.hgt') or lower.endswith('.hgt.zip')
+
+
+def read_dat_file(filepath):
+    """Read all blocks from a DAT or DAT.gz file."""
+    if filepath.endswith('.gz'):
+        with gzip.open(filepath, 'rb') as f:
+            data = f.read()
+    else:
+        with open(filepath, 'rb') as f:
+            data = f.read()
+
+    blocks = []
+    num_blocks = len(data) // IO_BLOCK_SIZE
+    tile_lat = None
+    tile_lon = None
+    spacing = None
+
+    for i in range(num_blocks):
+        block_data = data[i * IO_BLOCK_SIZE:(i + 1) * IO_BLOCK_SIZE]
+        if len(block_data) < IO_BLOCK_SIZE:
+            break
+
+        bitmap, lat_e7, lon_e7, crc, version, blk_spacing = struct.unpack('<QiiHHH', block_data[:22])
+
+        if bitmap == 0 and lat_e7 == 0 and lon_e7 == 0:
+            continue
+
+        height_data = block_data[22:22 + GRID_SIZE_X * GRID_SIZE_Y * 2]
+        if len(height_data) < GRID_SIZE_X * GRID_SIZE_Y * 2:
+            continue
+
+        heights = np.zeros((GRID_SIZE_X, GRID_SIZE_Y), dtype=np.int16)
+        for gx in range(GRID_SIZE_X):
+            offset = gx * GRID_SIZE_Y * 2
+            heights[gx, :] = struct.unpack('<%dh' % GRID_SIZE_Y,
+                                           height_data[offset:offset + GRID_SIZE_Y * 2])
+
+        trailer_offset = 22 + GRID_SIZE_X * GRID_SIZE_Y * 2
+        grid_idx_x, grid_idx_y, lon_deg, lat_deg = struct.unpack('<HHhb', block_data[trailer_offset:trailer_offset + 7])
+
+        if tile_lat is None:
+            tile_lat = lat_deg
+            tile_lon = lon_deg
+            spacing = blk_spacing
+
+        blocks.append({
+            'grid_idx_x': grid_idx_x,
+            'grid_idx_y': grid_idx_y,
+            'heights': heights,
+        })
+
+    return blocks, tile_lat, tile_lon, spacing
+
+
+def blocks_to_grid(blocks):
+    """Assemble blocks into a single height grid using block indices.
+
+    Blocks overlap by 4 grid points in each direction, so placement
+    uses BLOCK_SPACING rather than GRID_SIZE.
+    """
+    max_idx_x = max(b['grid_idx_x'] for b in blocks)
+    max_idx_y = max(b['grid_idx_y'] for b in blocks)
+
+    total_x = max_idx_x * BLOCK_SPACING_X + GRID_SIZE_X
+    total_y = max_idx_y * BLOCK_SPACING_Y + GRID_SIZE_Y
+
+    height_grid = np.zeros((total_x, total_y), dtype=np.int16)
+
+    for block in blocks:
+        x_start = block['grid_idx_x'] * BLOCK_SPACING_X
+        y_start = block['grid_idx_y'] * BLOCK_SPACING_Y
+        height_grid[x_start:x_start + GRID_SIZE_X,
+                    y_start:y_start + GRID_SIZE_Y] = block['heights']
+
+    return height_grid
+
+
+def height_to_rgb(height_grid):
+    """Convert height grid to RGB image.
+
+    0 = black. Non-zero heights mapped blue (lowest) to red (highest).
+    """
+    rgb = np.zeros((*height_grid.shape, 3), dtype=np.uint8)
+
+    nonzero = height_grid != 0
+    if not np.any(nonzero):
+        return rgb
+
+    nz_min = height_grid[nonzero].min()
+    nz_max = height_grid[nonzero].max()
+
+    if nz_max == nz_min:
+        # All non-zero values the same - use mid colour
+        rgb[nonzero] = [128, 0, 128]
+        return rgb
+
+    # Normalise non-zero heights to 0..1
+    t = (height_grid[nonzero].astype(np.float32) - nz_min) / (nz_max - nz_min)
+
+    # Blue (0,0,255) at t=0 to Red (255,0,0) at t=1
+    rgb[nonzero, 0] = (t * 255).astype(np.uint8)         # R
+    rgb[nonzero, 1] = 0                                   # G
+    rgb[nonzero, 2] = ((1 - t) * 255).astype(np.uint8)   # B
+
+    return rgb
+
+
+def load_file(filepath):
+    """Load a DAT or HGT file and return the height grid and tile info, or None."""
+    print(f"Reading {filepath}...")
+
+    if is_hgt_file(filepath):
+        try:
+            height_grid, tile_lat, tile_lon, spacing = read_hgt_file(filepath)
+            print(f"  HGT grid: {height_grid.shape[0]} x {height_grid.shape[1]}")
+        except Exception as e:
+            print(f"  Error reading HGT file: {e}")
+            return None, None, None, None
+    else:
+        blocks, tile_lat, tile_lon, spacing = read_dat_file(filepath)
+        print(f"  {len(blocks)} blocks")
+
+        if not blocks:
+            print(f"  No valid blocks found in {filepath}")
+            return None, None, None, None
+
+        height_grid = blocks_to_grid(blocks)
+        print(f"  Grid: {height_grid.shape[0]} x {height_grid.shape[1]}")
+
+    print(f"  Tile: lat={tile_lat}, lon={tile_lon}, spacing={spacing}m")
+
+    nz = height_grid[height_grid != 0]
+    if len(nz):
+        print(f"  Altitude: {nz.min()}m to {nz.max()}m")
+
+    return height_grid, tile_lat, tile_lon, spacing
+
+
+def grid_to_latlon(grid_x, grid_y, tile_lat, tile_lon, spacing):
+    """Convert grid coordinates to lat/lon.
+
+    grid_x is north (latitude), grid_y is east (longitude).
+    spacing is in metres.
+    """
+    # Approximate metres per degree
+    lat_m_per_deg = 111320.0
+    lon_m_per_deg = 111320.0 * np.cos(np.radians(tile_lat + 0.5))
+
+    lat = tile_lat + (grid_x * spacing) / lat_m_per_deg
+    lon = tile_lon + (grid_y * spacing) / lon_m_per_deg
+    return lat, lon
+
+
+def show_file(datfile, plt):
+    """Open a viewer window for one DAT file."""
+    height_grid, tile_lat, tile_lon, spacing = load_file(datfile)
+    if height_grid is None:
+        return
+
+    rgb = height_to_rgb(height_grid)
+
+    # Flip so north is up (row 0 = bottom of grid = south)
+    rgb = rgb[::-1, :, :]
+    height_display = height_grid[::-1, :]
+    grid_rows = height_display.shape[0]
+
+    fig, ax = plt.subplots(figsize=(12, 8))
+    ax.imshow(rgb, aspect='equal', interpolation='nearest')
+    ax.set_axis_off()
+    fig.suptitle(datfile)
+    fig.canvas.manager.set_window_title(datfile)
+
+    def format_coord(x, y):
+        ix, iy = int(x + 0.5), int(y + 0.5)
+        if 0 <= iy < height_display.shape[0] and 0 <= ix < height_display.shape[1]:
+            h = height_display[iy, ix]
+            # Convert display coords back to grid coords (flip y)
+            grid_x = grid_rows - 1 - iy
+            grid_y = ix
+            lat, lon = grid_to_latlon(grid_x, grid_y, tile_lat, tile_lon, spacing)
+            return f'lat={lat:.6f}  lon={lon:.6f}  height={h}m'
+        return ''
+
+    ax.format_coord = format_coord
+    plt.tight_layout()
+
+
+def diff_to_rgb(diff_grid):
+    """Convert a signed difference grid to RGB.
+
+    0 = black. Negative = blue, positive = red.
+    Uses 98th percentile for scaling so outliers don't wash out small diffs.
+    """
+    rgb = np.zeros((*diff_grid.shape, 3), dtype=np.uint8)
+
+    nonzero = diff_grid != 0
+    if not np.any(nonzero):
+        return rgb
+
+    # Use 98th percentile instead of max to avoid outliers washing out the image
+    abs_vals = np.abs(diff_grid[nonzero])
+    scale = np.percentile(abs_vals, 98)
+    if scale == 0:
+        scale = abs_vals.max()
+    if scale == 0:
+        return rgb
+
+    # Normalise to -1..1, clipping outliers
+    t = np.clip(diff_grid[nonzero].astype(np.float32) / scale, -1, 1)
+
+    # Positive (red), negative (blue)
+    pos = t > 0
+    neg = t < 0
+
+    nz_indices = np.where(nonzero)
+    pos_idx = tuple(idx[pos] for idx in nz_indices)
+    neg_idx = tuple(idx[neg] for idx in nz_indices)
+
+    rgb[pos_idx[0], pos_idx[1], 0] = (t[pos] * 255).astype(np.uint8)
+    rgb[neg_idx[0], neg_idx[1], 2] = (-t[neg] * 255).astype(np.uint8)
+
+    return rgb
+
+
+def resample_grid(grid, old_spacing, new_spacing):
+    """Resample a grid to a different spacing using nearest-neighbour."""
+    if old_spacing == new_spacing:
+        return grid
+    scale = old_spacing / new_spacing
+    new_rows = int(grid.shape[0] * scale)
+    new_cols = int(grid.shape[1] * scale)
+    # Create index arrays for nearest-neighbour resampling
+    row_idx = (np.arange(new_rows) / scale).astype(int)
+    col_idx = (np.arange(new_cols) / scale).astype(int)
+    row_idx = np.clip(row_idx, 0, grid.shape[0] - 1)
+    col_idx = np.clip(col_idx, 0, grid.shape[1] - 1)
+    return grid[row_idx][:, col_idx]
+
+
+def show_diff(file1, file2, plt):
+    """Show two files and their difference."""
+    grid1, tile_lat1, tile_lon1, spacing1 = load_file(file1)
+    grid2, tile_lat2, tile_lon2, spacing2 = load_file(file2)
+
+    if grid1 is None or grid2 is None:
+        return
+
+    # Use first file's tile info for coordinate display
+    tile_lat = tile_lat1 if tile_lat1 is not None else tile_lat2
+    tile_lon = tile_lon1 if tile_lon1 is not None else tile_lon2
+
+    # Resample to finer spacing if different
+    if spacing1 != spacing2:
+        target_spacing = min(spacing1, spacing2)
+        print(f"  Resampling to {target_spacing}m spacing for comparison")
+        grid1 = resample_grid(grid1, spacing1, target_spacing)
+        grid2 = resample_grid(grid2, spacing2, target_spacing)
+        spacing = target_spacing
+    else:
+        spacing = spacing1
+
+    # Pad smaller grid to match larger
+    rows = max(grid1.shape[0], grid2.shape[0])
+    cols = max(grid1.shape[1], grid2.shape[1])
+
+    def pad_grid(g):
+        if g.shape[0] < rows or g.shape[1] < cols:
+            p = np.zeros((rows, cols), dtype=g.dtype)
+            p[:g.shape[0], :g.shape[1]] = g
+            return p
+        return g
+
+    grid1 = pad_grid(grid1)
+    grid2 = pad_grid(grid2)
+
+    diff = grid1.astype(np.int32) - grid2.astype(np.int32)
+    n_diff = np.count_nonzero(diff)
+    print(f"  Diff: {n_diff} pixels differ, range {diff.min()} to {diff.max()}")
+
+    rgb1 = height_to_rgb(grid1)[::-1, :, :]
+    rgb2 = height_to_rgb(grid2)[::-1, :, :]
+    rgb_diff = diff_to_rgb(diff)[::-1, :, :]
+    h1 = grid1[::-1, :]
+    h2 = grid2[::-1, :]
+    d = diff[::-1, :]
+    grid_rows = h1.shape[0]
+    disp_spacing = spacing  # capture for closure
+
+    def format1(x, y):
+        ix, iy = int(x + 0.5), int(y + 0.5)
+        if 0 <= iy < h1.shape[0] and 0 <= ix < h1.shape[1]:
+            grid_x = grid_rows - 1 - iy
+            grid_y = ix
+            lat, lon = grid_to_latlon(grid_x, grid_y, tile_lat, tile_lon, disp_spacing)
+            return f'lat={lat:.6f}  lon={lon:.6f}  h1={h1[iy,ix]}m  h2={h2[iy,ix]}m  diff={d[iy,ix]}m'
+        return ''
+
+    # File 1
+    fig1, ax1 = plt.subplots(figsize=(12, 8))
+    ax1.imshow(rgb1, aspect='equal', interpolation='nearest')
+    ax1.set_axis_off()
+    fig1.suptitle(file1)
+    fig1.canvas.manager.set_window_title(file1)
+    ax1.format_coord = format1
+    plt.tight_layout()
+
+    # File 2
+    fig2, ax2 = plt.subplots(figsize=(12, 8))
+    ax2.imshow(rgb2, aspect='equal', interpolation='nearest')
+    ax2.set_axis_off()
+    fig2.suptitle(file2)
+    fig2.canvas.manager.set_window_title(file2)
+    ax2.format_coord = format1
+    plt.tight_layout()
+
+    # Diff
+    fig3, ax3 = plt.subplots(figsize=(12, 8))
+    ax3.imshow(rgb_diff, aspect='equal', interpolation='nearest')
+    ax3.set_axis_off()
+    fig3.suptitle(f"Diff: {file1} - {file2}")
+    fig3.canvas.manager.set_window_title(f"Diff ({n_diff} pixels differ)")
+    ax3.format_coord = format1
+    plt.tight_layout()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Visualise ArduPilot terrain DAT files or SRTM HGT files')
+    parser.add_argument('datfiles', nargs='+', help='Path to .DAT, .DAT.gz, .hgt, or .hgt.zip files')
+    parser.add_argument('--diff', action='store_true',
+                        help='Show difference between exactly 2 files')
+    args = parser.parse_args()
+
+    if args.diff:
+        if len(args.datfiles) != 2:
+            print("--diff requires exactly 2 files")
+            sys.exit(1)
+
+    import matplotlib.pyplot as plt
+
+    if args.diff:
+        show_diff(args.datfiles[0], args.datfiles[1], plt)
+    else:
+        for datfile in args.datfiles:
+            show_file(datfile, plt)
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()

--- a/zcmpdir
+++ b/zcmpdir
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Compare two directories of .gz files by their uncompressed contents."""
+
+import gzip
+import os
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <dir1> <dir2>")
+        sys.exit(1)
+
+    dir1, dir2 = sys.argv[1], sys.argv[2]
+
+    files1 = {f for f in os.listdir(dir1) if f.endswith('.gz')}
+    files2 = {f for f in os.listdir(dir2) if f.endswith('.gz')}
+    common = sorted(files1 & files2)
+
+    if not common:
+        print("No common .gz files found")
+        sys.exit(0)
+
+    n_diff = 0
+    for name in common:
+        with gzip.open(os.path.join(dir1, name), 'rb') as f:
+            data1 = f.read()
+        with gzip.open(os.path.join(dir2, name), 'rb') as f:
+            data2 = f.read()
+
+        if data1 == data2:
+            continue
+
+        diff_bytes = 0
+        for a, b in zip(data1, data2):
+            if a != b:
+                diff_bytes += 1
+        diff_bytes += abs(len(data1) - len(data2))
+
+        print(f"{name}: {diff_bytes} bytes differ (sizes {len(data1)}/{len(data2)})")
+        n_diff += 1
+
+    print(f"{len(common)} files compared, {n_diff} differ")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds detection and selective regeneration for tiles affected by the ocean tile bug. The --regen-ocean flag scans existing DAT.gz files and only regenerates those with both zeros and non-zeros (coastal tiles that could have been corrupted).