### PR TITLE
index.html: use https tile URL to fix Firefox 403 on OSM tiles

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -92,8 +92,8 @@
 <script>
     var circle;
     var mymap = L.map('mapid').setView([51.505, -0.09], 5);
-    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
     }).addTo(mymap);
 
     mymap.on('click', function (e) {


### PR DESCRIPTION
OSM's tile servers require a Referer header, and Firefox's default referrer policy strips it on https->http downgrade, producing 403s. Switch to https://tile.openstreetmap.org/ (the canonical URL).