### PR TITLE
create_continents.py: rebuild continent zips from the current tiles

### DIFF
--- a/create_continents.py
+++ b/create_continents.py
@@ -1,78 +1,285 @@
 #!/usr/bin/env python3
 '''
 create ardupilot terrain database files as continents
+
+Builds one zip per continent from the current .DAT.gz tiles. Continent
+membership comes from the continent subdirectories of an SRTM3 HGT tree
+(eg. /mnt/terrain_data/data/SRTM3/Eurasia/*.hgt.zip). Tiles that are in
+an existing continent zip but no longer in the HGT tree are kept, and
+tiles with no continent (the Misc/ directory) are assigned to the
+nearest continent.
+
+Every tile is checked for version_minor >= TERRAIN_VERSION_MINOR_MIN
+before it is added; ArduPilot fails the "terrain data expired" pre-arm
+check on anything older.
 '''
 import os
-import zipfile
+import re
+import sys
 import gzip
-from io import BytesIO
-
-from MAVProxy.modules.mavproxy_map import srtm
+import math
+import struct
+import zipfile
 from argparse import ArgumentParser
+from multiprocessing import Pool
 
-def compressFiles(fileList, continent, outfolder):
-    # create a zip file comprised of dat.gz tiles
-    zipthis = os.path.join(outfolder, continent + ".zip")
-    tmp_zipthis = zipthis + ".tmp"
+IO_BLOCK_SIZE = 2048
+VERSION_MINOR_OFFSET = 1821
+TERRAIN_GRID_FORMAT_VERSION = 1
+# must match TERRAIN_VERSION_MINOR_MIN in ArduPilot's AP_Terrain.h
+VERSION_MINOR_MIN = 1
 
-    with zipfile.ZipFile(tmp_zipthis, 'w') as terrain_zip:
-        for fn in fileList:
+# continent directories that don't name a real continent
+NON_CONTINENT = frozenset(['Misc', 'USGS'])
+
+NAME_RE = re.compile(r'^([NS])(\d{2})([EW])(\d{3})')
+
+
+def tile_latlon(name):
+    '''(lat, lon) from a tile name like N47E018'''
+    m = NAME_RE.match(name)
+    if m is None:
+        return None
+    lat = int(m.group(2))
+    lon = int(m.group(4))
+    if m.group(1) == 'S':
+        lat = -lat
+    if m.group(3) == 'W':
+        lon = -lon
+    return (lat, lon)
+
+
+def tile_names(directory):
+    '''tile names (no extension) for the .hgt.zip files in a directory'''
+    names = set()
+    for f in os.listdir(directory):
+        if f.endswith('.hgt.zip') and NAME_RE.match(f):
+            names.add(f[:-len('.hgt.zip')])
+    return names
+
+
+def hgt_mapping(hgtdir):
+    '''map tile name -> continent from an HGT tree with continent subdirs'''
+    mapping = {}
+    unassigned = set()
+    for entry in sorted(os.listdir(hgtdir)):
+        subdir = os.path.join(hgtdir, entry)
+        if not os.path.isdir(subdir):
+            continue
+        names = tile_names(subdir)
+        if entry in NON_CONTINENT:
+            unassigned |= names
+        else:
+            for n in names:
+                mapping[n] = entry
+    return mapping, unassigned
+
+
+def legacy_mapping(contdir):
+    '''map tile name -> continent from the existing continent zips'''
+    mapping = {}
+    if contdir is None or not os.path.isdir(contdir):
+        return mapping
+    for f in sorted(os.listdir(contdir)):
+        if not f.endswith('.zip'):
+            continue
+        continent = f[:-len('.zip')]
+        with zipfile.ZipFile(os.path.join(contdir, f)) as zf:
+            for n in zf.namelist():
+                n = os.path.basename(n)
+                if n.endswith('.DAT'):
+                    mapping[n[:-len('.DAT')]] = continent
+    return mapping
+
+
+def placed_tiles(mapping):
+    '''sorted (name, continent, lat, lon) for tiles with a known continent'''
+    tiles = []
+    for name in sorted(mapping):
+        pos = tile_latlon(name)
+        if pos is not None:
+            tiles.append((name, mapping[name], pos[0], pos[1]))
+    return tiles
+
+
+def nearest_continent(name, tiles):
+    '''assign a tile to the continent of the closest placed tile'''
+    pos = tile_latlon(name)
+    if pos is None:
+        return None
+    best = None
+    best_d = None
+    for (_, continent, olat, olon) in tiles:
+        # longitude wrap: shortest way around the globe
+        dlon = abs(pos[1] - olon)
+        if dlon > 180:
+            dlon = 360 - dlon
+        # longitude degrees shrink towards the poles
+        dlon *= math.cos(math.radians((pos[0] + olat) * 0.5))
+        d = (pos[0] - olat) ** 2 + dlon ** 2
+        # tiles are sorted by name, so ties go to the first name
+        if best_d is None or d < best_d:
+            best_d = d
+            best = continent
+    return best
+
+
+def check_version_minor(data):
+    '''return the set of version_minor values in a .DAT'''
+    values = set()
+    for off in range(0, len(data) - VERSION_MINOR_OFFSET, IO_BLOCK_SIZE):
+        version = struct.unpack_from('<H', data, off + 18)[0]
+        if version == TERRAIN_GRID_FORMAT_VERSION:
+            values.add(data[off + VERSION_MINOR_OFFSET])
+    return values
+
+
+def build_continent(job):
+    '''build one continent zip, returns (continent, total, done, missing, old)'''
+    continent, names, tilesdir, outfolder, dry_run = job
+
+    zipthis = os.path.join(outfolder, continent + '.zip')
+    tmp_zipthis = zipthis + '.tmp'
+
+    missing = []
+    old = []
+    written = 0
+
+    # a dry run reads and checks every tile, it just doesn't write the zip
+    terrain_zip = None
+    if not dry_run:
+        terrain_zip = zipfile.ZipFile(tmp_zipthis, 'w', allowZip64=True)
+
+    try:
+        for name in names:
+            fn = os.path.join(tilesdir, name + '.DAT.gz')
             if not os.path.exists(fn):
-                #download if required
-                print("Downloading " + os.path.basename(fn))
-                g = urllib.request.urlopen('https://terrain.ardupilot.org/data/tilesapm41/' +
-                                           os.path.basename(fn))
-                print("Downloaded " + os.path.basename(fn))
-                with open(fn, 'b+w') as f:
-                    f.write(g.read())
-
-            # need to decompress file and pass to zip
-            with gzip.open(fn, 'r') as f_in:
-                myio = BytesIO(f_in.read())
-                print("Decomp " + os.path.basename(fn))
-
-                # and add file to zip
-                terrain_zip.writestr(os.path.basename(fn)[:-3], myio.read(),
+                missing.append(name)
+                continue
+            with gzip.open(fn, 'rb') as f_in:
+                data = f_in.read()
+            versions = check_version_minor(data)
+            if not versions or min(versions) < VERSION_MINOR_MIN:
+                old.append(name)
+            if terrain_zip is not None:
+                terrain_zip.writestr(name + '.DAT', data,
                                      compress_type=zipfile.ZIP_DEFLATED)
+            written += 1
+    finally:
+        if terrain_zip is not None:
+            terrain_zip.close()
 
-    # Atomic rename to final location
+    if dry_run:
+        return (continent, len(names), written, missing, old)
+
+    if old or missing:
+        # publishing a stale tile re-creates the "terrain data expired"
+        # pre-arm, and a missing one would silently drop coverage
+        os.unlink(tmp_zipthis)
+        return (continent, len(names), written, missing, old)
+
     os.rename(tmp_zipthis, zipthis)
-    return True
+    return (continent, len(names), written, missing, old)
 
-if __name__ == '__main__':
-    this_path = os.path.dirname(os.path.realpath(__file__))
 
+def main():
     parser = ArgumentParser(description='terrain data continent creator')
 
-    parser.add_argument("infolder", type=str, default="./files")
-    parser.add_argument("outfolder", type=str, default="./continents")
-    parser.add_argument("--cachedir", type=str, default=None,
-                        help="Directory containing filelist_python for continent mapping")
+    parser.add_argument('--tiles-dir', default='/mnt/terrain_data/data/tilesdat3',
+                        help='directory of .DAT.gz tiles')
+    parser.add_argument('--hgt-dir', default='/mnt/terrain_data/data/SRTM3',
+                        help='SRTM3 HGT tree with continent subdirectories')
+    parser.add_argument('--out-dir', default='/mnt/terrain_data/data/continentsdat3',
+                        help='output directory for the continent zips')
+    parser.add_argument('--old-continents', default=None,
+                        help='existing continent zip dir, used to keep membership '
+                             'of tiles no longer in the HGT tree (defaults to --out-dir)')
+    parser.add_argument('--continent', action='append', default=None,
+                        help='only build this continent (may be repeated)')
+    parser.add_argument('--parallel', type=int, default=1,
+                        help='number of continents to build at once')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='check every tile the build would use, write nothing')
 
     args = parser.parse_args()
 
-    downloader = srtm.SRTMDownloader(debug=False, cachedir=args.cachedir)
-    downloader.loadFileList()
+    if args.old_continents is None:
+        args.old_continents = args.out_dir
+
+    mapping, unassigned = hgt_mapping(args.hgt_dir)
+    print('HGT tree: %u tiles in %u continents, %u unassigned' %
+          (len(mapping), len(set(mapping.values())), len(unassigned)))
+
+    # keep tiles that were published before but have since left the HGT tree
+    legacy = legacy_mapping(args.old_continents)
+    kept = 0
+    for name, continent in legacy.items():
+        if name not in mapping:
+            mapping[name] = continent
+            unassigned.discard(name)
+            kept += 1
+    if legacy:
+        print('kept %u tiles only present in the old continent zips' % kept)
+
+    # tiles with no continent go to their nearest neighbour's continent
+    base = placed_tiles(mapping)
+    for name in sorted(unassigned):
+        continent = nearest_continent(name, base)
+        if continent is None:
+            print('cannot place %s' % name)
+            continue
+        print('placing %s in %s' % (name, continent))
+        mapping[name] = continent
 
     continents = {}
+    for name, continent in mapping.items():
+        continents.setdefault(continent, []).append(name)
 
-    # Create mappings of long/lat to continent
-    for (lonlat, contfile) in downloader.filelist.items():
-        continent = str(contfile[0][:-1])
-        filename = os.path.join(this_path, args.infolder, str(contfile[1]).split(".")[0] + ".DAT.gz")
-        print(continent + " in " + filename)
+    if args.continent:
+        for c in args.continent:
+            if c not in continents:
+                print('unknown continent %s, have %s' %
+                      (c, ', '.join(sorted(continents))))
+                sys.exit(1)
+        continents = {c: continents[c] for c in args.continent}
 
-        # add to database
-        if continent != '' and continent != 'USGS':
-            if continent in continents:
-                continents[continent].append(filename)
-            else:
-                continents[continent] = [filename]
+    print('Continents: %s' % ', '.join('%s=%u' % (c, len(continents[c]))
+                                       for c in sorted(continents)))
+    print('Total tiles: %u' % sum(len(v) for v in continents.values()))
 
-    print("Continents are: " + str(continents.keys()))
+    if not args.dry_run and not os.path.isdir(args.out_dir):
+        os.makedirs(args.out_dir)
 
-    # Add the files
-    for continent in continents:
-        print("Processing: " + continent)
-        files = continents[continent]
-        compressFiles(files, continent, args.outfolder)
+    jobs = [(c, sorted(continents[c]), args.tiles_dir, args.out_dir, args.dry_run)
+            for c in sorted(continents, key=lambda c: -len(continents[c]))]
+
+    if args.parallel > 1:
+        with Pool(args.parallel) as pool:
+            failed = report(pool.imap_unordered(build_continent, jobs), args.dry_run)
+    else:
+        failed = report((build_continent(j) for j in jobs), args.dry_run)
+
+    sys.exit(1 if failed else 0)
+
+
+def report(results, dry_run):
+    '''print per continent results, return True if any continent failed'''
+    failed = False
+    for (continent, total, written, missing, old) in results:
+        print('%s: %u tiles, %u %s' %
+              (continent, total, written, 'checked' if dry_run else 'written'))
+        if missing:
+            failed = True
+            print('  %u tiles missing from tiles dir: %s' %
+                  (len(missing), ' '.join(missing[:10])))
+        if old:
+            failed = True
+            print('  %u tiles have version_minor < %u: %s' %
+                  (len(old), VERSION_MINOR_MIN, ' '.join(old[:10])))
+        if (missing or old) and not dry_run:
+            print('  %s.zip NOT written' % continent)
+    return failed
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The continent zips could no longer be regenerated. Continent membership came from the MAVProxy filelist_python pickle, but create_filelist.py writes every entry with a "/" prefix, so no tile mapped to a continent and the script produced nothing. It also needed MAVProxy installed, and the download fallback called urllib without importing it.

Take membership from the continent subdirectories of the SRTM3 HGT tree instead, union in the membership of the existing zips so no published tile is dropped, and place tiles from Misc/ with their nearest mapped neighbour.

Check version_minor on every tile as it is written and refuse to publish a zip containing stale tiles. The zips on the server were built before the tiles were stamped with version_minor=1, so all of them failed ArduPilot's "terrain data expired" pre-arm check.